### PR TITLE
added scale tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -204,7 +204,6 @@
 					}
 				],
 				"@typescript-eslint/no-explicit-any": "error",
-				"@typescript-eslint/no-namespace": "off",
 				"@typescript-eslint/no-shadow": "error",
 				"arrow-body-style": [
 					"error",

--- a/.run/test_scale.run.xml
+++ b/.run/test_scale.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test:scale" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="test:scale" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 	"scripts": {
 		"build": "rimraf dist; tsc",
 		"lint": "eslint . --ext .ts",
-		"test": "jest"
+		"test": "jest --testPathIgnorePatterns=scale",
+		"test:scale": "jest --testPathPattern=scale"
 	},
 	"dependencies": {},
 	"devDependencies": {

--- a/src/test/constants/scale-testing-constants.ts
+++ b/src/test/constants/scale-testing-constants.ts
@@ -1,0 +1,41 @@
+import {performance} from "perf_hooks";
+
+/**
+ * Scale Testing:
+ *
+ * Each set listed below contains all the multiples of a given number
+ * from `0` up to `10 Million`.
+ *
+ * Note: Sets with `100 Million` values will fail to instantiate.
+ */
+export namespace multiples {
+	export function of1(): ReadonlySet<number> {
+		return new Set<number>(Array.from(
+			{ length: 10_000_000 },
+			(_, index) => index),
+		);
+	}
+
+	export function of2(): ReadonlySet<number> {
+		return new Set<number>(Array.from(
+			{ length: 5_000_000 },
+			(_, index) => index * 2),
+		);
+	}
+
+	export function of3(): ReadonlySet<number> {
+		return new Set<number>(Array.from(
+			{ length: 3_333_333 },
+			(_, index) => index * 3),
+		);
+	}
+}
+
+export function time<T>(methodName: string, method: () => T): T {
+	const timeStart = performance.now();
+	const result: T = method();
+	const timeEnd = performance.now();
+
+	console.log(`${ methodName } took ${ (timeEnd - timeStart).toFixed(3) } ms`);
+	return result;
+}

--- a/src/test/constants/scale-testing-constants.ts
+++ b/src/test/constants/scale-testing-constants.ts
@@ -1,27 +1,27 @@
 import { performance } from 'perf_hooks';
 
 /**
- * Scale Testing:
+ * Scale Testing Sets:
  *
  * Each set listed below contains all the multiples of a given number
  * from `0` up to `10 Million`.
  *
  * Note: Sets with `100 Million` values will fail to instantiate.
  */
-export namespace multiples {
-	export function of1(): ReadonlySet<number> {
-		return of(1, 10_000_000);
+export abstract class Multiples {
+	public static of1(): ReadonlySet<number> {
+		return this.of(1, 10_000_000);
 	}
 
-	export function of2(): ReadonlySet<number> {
-		return of(2, 5_000_000);
+	public static of2(): ReadonlySet<number> {
+		return this.of(2, 5_000_000);
 	}
 
-	export function of3(): ReadonlySet<number> {
-		return of(3, 3_333_333);
+	public static of3(): ReadonlySet<number> {
+		return this.of(3, 3_333_333);
 	}
 
-	function of(factor: number, size: number): ReadonlySet<number> {
+	private static of(factor: number, size: number): ReadonlySet<number> {
 		return new Set<number>(Array.from(
 			{ length: size },
 			(_, index) => index * factor),

--- a/src/test/constants/scale-testing-constants.ts
+++ b/src/test/constants/scale-testing-constants.ts
@@ -1,4 +1,4 @@
-import {performance} from "perf_hooks";
+import { performance } from 'perf_hooks';
 
 /**
  * Scale Testing:

--- a/src/test/constants/scale-testing-constants.ts
+++ b/src/test/constants/scale-testing-constants.ts
@@ -10,23 +10,21 @@ import { performance } from 'perf_hooks';
  */
 export namespace multiples {
 	export function of1(): ReadonlySet<number> {
-		return new Set<number>(Array.from(
-			{ length: 10_000_000 },
-			(_, index) => index),
-		);
+		return of(1, 10_000_000);
 	}
 
 	export function of2(): ReadonlySet<number> {
-		return new Set<number>(Array.from(
-			{ length: 5_000_000 },
-			(_, index) => index * 2),
-		);
+		return of(2, 5_000_000);
 	}
 
 	export function of3(): ReadonlySet<number> {
+		return of(3, 3_333_333);
+	}
+
+	function of(factor: number, size: number): ReadonlySet<number> {
 		return new Set<number>(Array.from(
-			{ length: 3_333_333 },
-			(_, index) => index * 3),
+			{ length: size },
+			(_, index) => index * factor),
 		);
 	}
 }

--- a/src/test/scale.test.ts
+++ b/src/test/scale.test.ts
@@ -4,12 +4,12 @@ import { equivalence } from '../functions/equivalence.function';
 import { intersection } from '../functions/intersection.function';
 import { union } from '../functions/union.function';
 import { xor } from '../functions/xor.function';
-import { multiples, time } from './constants/scale-testing-constants';
+import { Multiples, time } from './constants/scale-testing-constants';
 
 describe('Scale Tests', () => {
-	const multiplesOf1 = time('copying 10_000_000', multiples.of1);
-	const multiplesOf2 = time('copying 5_000_000', multiples.of2);
-	const multiplesOf3 = time('copying 3_333_333', multiples.of3);
+	const multiplesOf1 = time('copying 10_000_000', Multiples.of1);
+	const multiplesOf2 = time('copying 5_000_000', Multiples.of2);
+	const multiplesOf3 = time('copying 3_333_333', Multiples.of3);
 
 	it('difference scale tests', () => {
 		const result1 = time('difference of 1', () => difference(multiplesOf1));

--- a/src/test/scale.test.ts
+++ b/src/test/scale.test.ts
@@ -6,17 +6,10 @@ import { union } from '../functions/union.function';
 import { xor } from '../functions/xor.function';
 import { multiples, time } from './constants/scale-testing-constants';
 
-let multiplesOf1: ReadonlySet<number>;
-let multiplesOf2: ReadonlySet<number>;
-let multiplesOf3: ReadonlySet<number>;
-
-beforeAll(() => {
-	multiplesOf1 = time('copying 10_000_000', multiples.of1);
-	multiplesOf2 = time('copying 5_000_000', multiples.of2);
-	multiplesOf3 = time('copying 3_333_333', multiples.of3);
-});
-
 describe('Scale Tests', () => {
+	const multiplesOf1 = time('copying 10_000_000', multiples.of1);
+	const multiplesOf2 = time('copying 5_000_000', multiples.of2);
+	const multiplesOf3 = time('copying 3_333_333', multiples.of3);
 
 	it('difference scale tests', () => {
 		const result1 = time('difference of 1', () => difference(multiplesOf1));

--- a/src/test/scale.test.ts
+++ b/src/test/scale.test.ts
@@ -1,0 +1,70 @@
+import { expect, it } from '@jest/globals';
+import { difference } from '../functions/difference.function';
+import { equivalence } from '../functions/equivalence.function';
+import { intersection } from '../functions/intersection.function';
+import { union } from '../functions/union.function';
+import { xor } from '../functions/xor.function';
+import { multiples, time } from './constants/scale-testing-constants';
+
+let multiplesOf1: ReadonlySet<number>;
+let multiplesOf2: ReadonlySet<number>;
+let multiplesOf3: ReadonlySet<number>;
+
+beforeAll(() => {
+	multiplesOf1 = time('copying 10_000_000', multiples.of1);
+	multiplesOf2 = time('copying 5_000_000', multiples.of2);
+	multiplesOf3 = time('copying 3_333_333', multiples.of3);
+});
+
+describe('Scale Tests', () => {
+
+	it('difference scale tests', () => {
+		const result1 = time('difference of 1', () => difference(multiplesOf1));
+		const result2 = time('difference of 2', () => difference(multiplesOf1, multiplesOf2));
+		const result3 = time('difference of 3', () => difference(multiplesOf1, multiplesOf2, multiplesOf3));
+
+		expect(result1.size).toBe(10_000_000);
+		expect(result2.size).toBe(5_000_000);
+		expect(result3.size).toBe(3_333_334);
+	});
+
+	it('equivalence scale tests', () => {
+		const result1 = time('equivalence of 1', () => equivalence(multiplesOf1));
+		const result2 = time('equivalence of 2', () => equivalence(multiplesOf1, multiplesOf2));
+		const result3 = time('equivalence of 3', () => equivalence(multiplesOf1, multiplesOf2, multiplesOf3));
+
+		expect(result1).toBe(true);
+		expect(result2).toBe(false);
+		expect(result3).toBe(false);
+	});
+
+	it('intersection scale tests', () => {
+		const result1 = time('intersection of 1', () => intersection(multiplesOf1));
+		const result2 = time('intersection of 2', () => intersection(multiplesOf1, multiplesOf2));
+		const result3 = time('intersection of 3', () => intersection(multiplesOf1, multiplesOf2, multiplesOf3));
+
+		expect(result1.size).toBe(10_000_000);
+		expect(result2.size).toBe(5_000_000);
+		expect(result3.size).toBe(1_666_667);
+	});
+
+	it('union scale tests', () => {
+		const result1 = time('union of 1', () => union(multiplesOf1));
+		const result2 = time('union of 2', () => union(multiplesOf1, multiplesOf2));
+		const result3 = time('union of 3', () => union(multiplesOf1, multiplesOf2, multiplesOf3));
+
+		expect(result1.size).toBe(10_000_000);
+		expect(result2.size).toBe(10_000_000);
+		expect(result3.size).toBe(10_000_000);
+	});
+
+	it('xor scale tests', () => {
+		const result1 = time('xor of 1', () => xor(multiplesOf1));
+		const result2 = time('xor of 2', () => xor(multiplesOf1, multiplesOf2));
+		const result3 = time('xor of 3', () => xor(multiplesOf1, multiplesOf2, multiplesOf3));
+
+		expect(result1.size).toBe(10_000_000);
+		expect(result2.size).toBe(5_000_000);
+		expect(result3.size).toBe(3_333_334);
+	});
+});


### PR DESCRIPTION
Scale tests are explicitly ignored in paths from the `npm test` command. To run them, use the `npm run test:scale` command instead.