### PR TITLE
export `sort` from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { difference } from './functions/difference.function';
 export { equivalence } from './functions/equivalence.function';
 export { intersection } from './functions/intersection.function';
+export { sort } from './functions/sort.function';
 export { union } from './functions/union.function';
 export { xor } from './functions/xor.function';

--- a/src/test/difference.function.test.ts
+++ b/src/test/difference.function.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { difference } from '../functions/difference.function';
-import { equivalence } from '../functions/equivalence.function';
+import { difference, equivalence } from '../index';
 import { empty, setA, setB, setC } from './constants/testing-constants';
 
 describe('difference', () => {

--- a/src/test/equivalence.function.test.ts
+++ b/src/test/equivalence.function.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { equivalence } from '../functions/equivalence.function';
+import { equivalence } from '../index';
 import { setA, setB, setC } from './constants/testing-constants';
 
 describe('equivalence', () => {

--- a/src/test/intersection.function.test.ts
+++ b/src/test/intersection.function.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { equivalence } from '../functions/equivalence.function';
-import { intersection } from '../functions/intersection.function';
+import { equivalence, intersection } from '../index';
 import { empty, setA, setB, setC } from './constants/testing-constants';
 
 describe('intersection', () => {

--- a/src/test/scale.test.ts
+++ b/src/test/scale.test.ts
@@ -1,10 +1,5 @@
 import { expect, it } from '@jest/globals';
-import { difference } from '../functions/difference.function';
-import { equivalence } from '../functions/equivalence.function';
-import { intersection } from '../functions/intersection.function';
-import { sort } from '../functions/sort.function';
-import { union } from '../functions/union.function';
-import { xor } from '../functions/xor.function';
+import { difference, equivalence, intersection, sort, union, xor } from '../index';
 import { Multiples, time } from './constants/scale-testing-constants';
 import { reverseComparator } from './constants/testing-constants';
 

--- a/src/test/sort.test.ts
+++ b/src/test/sort.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { equivalence } from '../functions/equivalence.function';
-import { sort } from '../functions/sort.function';
+import { equivalence, sort } from '../index';
 import { empty, reverseComparator, setA, standardComparator } from './constants/testing-constants';
 
 describe('sort', () => {

--- a/src/test/union.function.test.ts
+++ b/src/test/union.function.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { equivalence } from '../functions/equivalence.function';
-import { union } from '../functions/union.function';
+import { equivalence, union } from '../index';
 import { empty, setA, setB, setC } from './constants/testing-constants';
 
 describe('union', () => {

--- a/src/test/xor.function.test.ts
+++ b/src/test/xor.function.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { equivalence } from '../functions/equivalence.function';
-import { xor } from '../functions/xor.function';
+import { equivalence, xor } from '../index';
 import { empty, setA, setB, setC } from './constants/testing-constants';
 
 describe('xor', () => {


### PR DESCRIPTION
An export for `sort` was not added to the `index.ts` in #11. This aims to fix that export.