### PR TITLE
improved copying performance of set operations

### DIFF
--- a/src/functions/difference.function.ts
+++ b/src/functions/difference.function.ts
@@ -11,7 +11,7 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A - B ≔ { x : (x ∈ A) ∧ (x ∉ B) }
  */
 export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>([ ...(sets[0] ?? new Set<T>()) ]);
+	const result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
 		sets[index]?.forEach(value => {

--- a/src/functions/intersection.function.ts
+++ b/src/functions/intersection.function.ts
@@ -9,7 +9,7 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	let result = new Set<T>([ ...sets[0] ?? new Set<T>() ]);
+	let result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
 		const _intersection = new Set<T>();

--- a/src/functions/union.function.ts
+++ b/src/functions/union.function.ts
@@ -9,7 +9,7 @@ export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∪ B ≔ { x : (x ∈ A) ∨ (x ∈ B) }
  */
 export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>([ ...sets[0] ?? new Set<T>() ]);
+	const result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
 		sets[index]?.forEach(value => {


### PR DESCRIPTION
Improved performance of initial copying operations:
```typescript
// old: copy into an array, then into another set
const result = new Set<T>([ ...(sets[0] ?? new Set<T>()) ]);

// new: copy directly into another set
const result = new Set<T>(sets[0] ?? new Set<T>());
```