### PR TITLE
improved xor performance

### DIFF
--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -1,6 +1,3 @@
-import { difference } from './difference.function';
-import { union } from './union.function';
-
 export function xor<T>(...sets: Set<T>[]): Set<T>;
 export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 
@@ -14,13 +11,19 @@ export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ⊖ B ≔ { x : (x ∈ A) ⊕ (x ∈ B) }
  */
 export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const differences: S[] = [];
+	const result = new Set<T>(sets[0] ?? new Set<T>());
+	const reusedValues = new Set<T>();
 
-	sets.forEach((set, index) => {
-		const otherSets = [ ...sets.slice(0, index), ...sets.slice(index + 1) ];
+	for (let index = 1; index < sets.length; index++) {
+		for (const value of sets[index]!) {
+			if (result.has(value)) {
+				result.delete(value);
+				reusedValues.add(value);
+			} else if (!reusedValues.has(value)) {
+				result.add(value);
+			}
+		}
+	}
 
-		differences.push(difference(set, ...otherSets) as S);
-	});
-
-	return union(...differences) as S;
+	return result as ReadonlySet<T> as S;
 }


### PR DESCRIPTION
Improved xor performance using custom implementation rather than calling `difference` and `union` internally.

## :o: original implementation:
Using `difference` and `union` internally.

|          | xor of 1 set: 10M | xor of 2 sets: 10M & 5M | xor of 3 sets: 10M, 5M, & 3M |
|:---------|:------------------|:------------------------|:-----------------------------|
| test 1:  | 6629.388 ms       | 8918.653 ms             | 11540.040 ms                 |
| test 2:  | 6463.766 ms       | 8907.801 ms             | 11917.361 ms                 |
| test 3:  | 6566.865 ms       | 8812.364 ms             | 11522.295 ms                 |
| test 4:  | 6639.678 ms       | 8727.676 ms             | 11625.841 ms                 |
| test 5:  | 7025.046 ms       | 8848.937 ms             | 11584.064 ms                 |
| average: | 6664.949 ms       | 8843.086 ms             | 11637.920 ms                 |

## :o: xor custom implementation _(option 1)_:
Calls `reusedValues.has` before calling `reusedValues.add`.

|                      | xor of 1 set: 10M | xor of 2 sets: 10M & 5M | xor of 3 sets: 10M, 5M, & 3M |
|:---------------------|:------------------|:------------------------|:-----------------------------|
| test 1:              | 3364.182 ms       | 6053.281 ms             | 7716.744 ms                  |
| test 2:              | 3312.582 ms       | 5920.478 ms             | 7481.409 ms                  |
| test 3:              | 3374.251 ms       | 5827.507 ms             | 7689.054 ms                  |
| test 4:              | 3589.623 ms       | 6137.061 ms             | 7608.236 ms                  |
| test 5:              | 3207.822 ms       | 5797.050 ms             | 7354.333 ms                  |
| average:             | 3369.692 ms       | 5947.075 ms             | 7569.955 ms                  |
| ***relative time:*** | ***50.558%***     | ***67.251%***           | ***65.046%***                |

## :heavy_check_mark: xor custom implementation _(option 2)_:
Always calls `reusedValues.add` instead of checking for a value first.

Notes:
- _relative time_ is a comparison of averages between this implementation and the original.
- On my machine, ~3200ms is how long it takes to copy a Set of size 10M. So this is approximately the minimum threshold we can aim for, given that the function is immutable and returns a copied Set.

|                      | xor of 1 set: 10M | xor of 2 sets: 10M & 5M | xor of 3 sets: 10M, 5M, & 3M |
|:---------------------|:------------------|:------------------------|:-----------------------------|
| test 1:              | 3432.722 ms       | 5572.122 ms             | 6884.741 ms                  |
| test 2:              | 3260.315 ms       | 5673.121 ms             | 6908.560 ms                  |
| test 3:              | 3331.252 ms       | 5913.558 ms             | 6921.396 ms                  |
| test 4:              | 3296.804 ms       | 5689.021 ms             | 7052.191 ms                  |
| test 5:              | 3424.290 ms       | 5797.473 ms             | 7237.603 ms                  |
| average:             | 3349.077 ms       | 5729.059 ms             | 7000.898 ms                  |
| ***relative time:*** | ***50.249%***     | ***64.786%***           | ***60.156%***                |
