### PR TITLE
marginally improved operations performances

### DIFF
--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -14,9 +14,9 @@ export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
-		sets[index]?.forEach(value => {
+		for (const value of sets[index]!) {
 			result.delete(value);
-		});
+		}
 	}
 
 	return result as ReadonlySet<T> as S;

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -14,11 +14,11 @@ export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	for (let index = 1; index < sets.length; index++) {
 		const _intersection = new Set<T>();
 
-		sets[index]?.forEach(value => {
+		for (const value of sets[index]!) {
 			if (result.has(value)) {
 				_intersection.add(value);
 			}
-		});
+		}
 
 		result = _intersection;
 	}

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -12,9 +12,9 @@ export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
-		sets[index]?.forEach(value => {
+		for (const value of sets[index]!) {
 			result.add(value);
-		});
+		}
 	}
 
 	return result as ReadonlySet<T> as S;

--- a/test/constants/scale-testing-constants.ts
+++ b/test/constants/scale-testing-constants.ts
@@ -3,22 +3,26 @@ import { performance } from 'perf_hooks';
 /**
  * Scale Testing Sets:
  *
- * Each set listed below contains all the multiples of a given number
- * from `0` up to `10 Million`.
+ * Each set listed below contains all the multiples
+ * of a given number, from `0` up to `15 Million`.
  *
- * Note: Sets with `100 Million` values will fail to instantiate.
+ * Note: Sets of `size > 16,777,216` will fail to instantiate,
+ * or will fail to add values afterwards, with the following error message:
+ * ```
+ * RangeError: Value undefined out of range for undefined options property undefined
+ * ```
  */
 export abstract class Multiples {
 	public static of1(): ReadonlySet<number> {
-		return Multiples.of(1, 10_000_000);
+		return Multiples.of(1, 15_000_000);
 	}
 
 	public static of2(): ReadonlySet<number> {
-		return Multiples.of(2, 5_000_000);
+		return Multiples.of(2, 7_500_000);
 	}
 
 	public static of3(): ReadonlySet<number> {
-		return Multiples.of(3, 3_333_333);
+		return Multiples.of(3, 5_000_000);
 	}
 
 	private static of(factor: number, size: number): ReadonlySet<number> {
@@ -29,11 +33,34 @@ export abstract class Multiples {
 	}
 }
 
-export function time<T>(methodName: string, method: () => T): T {
-	const timeStart = performance.now();
-	const result: T = method();
-	const timeEnd = performance.now();
+export abstract class Timer {
+	private static readonly timings = new Map<string, number[]>();
 
-	console.log(`${ methodName } took ${ (timeEnd - timeStart).toFixed(3) } ms`);
-	return result;
+	public static time<T>(methodName: string, method: () => T): T {
+		const timeStart = performance.now();
+		const result: T = method();
+		const timeEnd = performance.now();
+
+		Timer.add(methodName, timeEnd - timeStart);
+		return result;
+	}
+
+	private static add(methodName: string, timing: number): void {
+		if (!this.timings.has(methodName)) {
+			this.timings.set(methodName, []);
+		}
+
+		this.timings.get(methodName)?.push(timing);
+	}
+
+	public static log(methodName: string): void {
+		const timings = this.timings.get(methodName);
+
+		if (typeof timings !== 'undefined') {
+			const formattedTimings = timings
+				.map(timing => `${ timing.toFixed(3) }ms`)
+				.join(', ');
+			console.log(`${ methodName }: [ ${ formattedTimings } ]`);
+		}
+	}
 }

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,27 +1,30 @@
 import { expect, it } from '@jest/globals';
 import { difference, disjoint, equivalence, intersection, sort, subset, superset, union, xor } from '../src';
-import { Multiples, time } from './constants/scale-testing-constants';
+import { Multiples, Timer } from './constants/scale-testing-constants';
 import { reverseComparator } from './constants/sort-testing-constants';
 
 describe('Scale Tests', () => {
-	const multiplesOf1 = time('copying 10_000_000', Multiples.of1);
-	const multiplesOf2 = time('copying 5_000_000', Multiples.of2);
-	const multiplesOf3 = time('copying 3_333_333', Multiples.of3);
+	const multiplesOf1 = Timer.time('copying multiples', Multiples.of1);
+	const multiplesOf2 = Timer.time('copying multiples', Multiples.of2);
+	const multiplesOf3 = Timer.time('copying multiples', Multiples.of3);
+	Timer.log('copying multiples');
 
 	it('difference scale tests', () => {
-		const result1 = time('difference of 1', () => difference(multiplesOf1));
-		const result2 = time('difference of 2', () => difference(multiplesOf1, multiplesOf2));
-		const result3 = time('difference of 3', () => difference(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('difference', () => difference(multiplesOf1));
+		const result2 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('difference');
 
-		expect(result1.size).toBe(10_000_000);
-		expect(result2.size).toBe(5_000_000);
-		expect(result3.size).toBe(3_333_334);
+		expect(result1.size).toBe(15_000_000);
+		expect(result2.size).toBe(7_500_000);
+		expect(result3.size).toBe(5_000_000);
 	});
 
 	it('disjoint scale tests', () => {
-		const result1 = time('disjoint of 1', () => disjoint(multiplesOf1));
-		const result2 = time('disjoint of 2', () => disjoint(multiplesOf1, multiplesOf2));
-		const result3 = time('disjoint of 3', () => disjoint(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('disjoint', () => disjoint(multiplesOf1));
+		const result2 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('disjoint');
 
 		expect(result1).toBe(true);
 		expect(result2).toBe(false);
@@ -29,9 +32,10 @@ describe('Scale Tests', () => {
 	});
 
 	it('equivalence scale tests', () => {
-		const result1 = time('equivalence of 1', () => equivalence(multiplesOf1));
-		const result2 = time('equivalence of 2', () => equivalence(multiplesOf1, multiplesOf2));
-		const result3 = time('equivalence of 3', () => equivalence(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('equivalence', () => equivalence(multiplesOf1));
+		const result2 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('equivalence');
 
 		expect(result1).toBe(true);
 		expect(result2).toBe(false);
@@ -39,19 +43,21 @@ describe('Scale Tests', () => {
 	});
 
 	it('intersection scale tests', () => {
-		const result1 = time('intersection of 1', () => intersection(multiplesOf1));
-		const result2 = time('intersection of 2', () => intersection(multiplesOf1, multiplesOf2));
-		const result3 = time('intersection of 3', () => intersection(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('intersection', () => intersection(multiplesOf1));
+		const result2 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('intersection');
 
-		expect(result1.size).toBe(10_000_000);
-		expect(result2.size).toBe(5_000_000);
-		expect(result3.size).toBe(1_666_667);
+		expect(result1.size).toBe(15_000_000);
+		expect(result2.size).toBe(7_500_000);
+		expect(result3.size).toBe(2_500_000);
 	});
 
 	it('subset scale tests', () => {
-		const result1 = time('subset of 1', () => subset(multiplesOf1));
-		const result2 = time('subset of 2', () => subset(multiplesOf1, multiplesOf2));
-		const result3 = time('subset of 3', () => subset(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('subset', () => subset(multiplesOf1));
+		const result2 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('subset');
 
 		expect(result1).toBe(true);
 		expect(result2).toBe(false);
@@ -59,9 +65,10 @@ describe('Scale Tests', () => {
 	});
 
 	it('superset scale tests', () => {
-		const result1 = time('superset of 1', () => superset(multiplesOf1));
-		const result2 = time('superset of 2', () => superset(multiplesOf1, multiplesOf2));
-		const result3 = time('superset of 3', () => superset(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('superset', () => superset(multiplesOf1));
+		const result2 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('superset');
 
 		expect(result1).toBe(true);
 		expect(result2).toBe(true);
@@ -69,32 +76,35 @@ describe('Scale Tests', () => {
 	});
 
 	it('union scale tests', () => {
-		const result1 = time('union of 1', () => union(multiplesOf1));
-		const result2 = time('union of 2', () => union(multiplesOf1, multiplesOf2));
-		const result3 = time('union of 3', () => union(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('union', () => union(multiplesOf1));
+		const result2 = Timer.time('union', () => union(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('union', () => union(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('union');
 
-		expect(result1.size).toBe(10_000_000);
-		expect(result2.size).toBe(10_000_000);
-		expect(result3.size).toBe(10_000_000);
+		expect(result1.size).toBe(15_000_000);
+		expect(result2.size).toBe(15_000_000);
+		expect(result3.size).toBe(15_000_000);
 	});
 
 	it('xor scale tests', () => {
-		const result1 = time('xor of 1', () => xor(multiplesOf1));
-		const result2 = time('xor of 2', () => xor(multiplesOf1, multiplesOf2));
-		const result3 = time('xor of 3', () => xor(multiplesOf1, multiplesOf2, multiplesOf3));
+		const result1 = Timer.time('xor', () => xor(multiplesOf1));
+		const result2 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2));
+		const result3 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2, multiplesOf3));
+		Timer.log('xor');
 
-		expect(result1.size).toBe(10_000_000);
-		expect(result2.size).toBe(5_000_000);
-		expect(result3.size).toBe(3_333_334);
+		expect(result1.size).toBe(15_000_000);
+		expect(result2.size).toBe(7_500_000);
+		expect(result3.size).toBe(5_000_000);
 	});
 
 	it('sort scale tests', () => {
-		const result1 = time('sort of 10M', () => sort(multiplesOf1, reverseComparator));
-		const result2 = time('sort of 5M', () => sort(multiplesOf2, reverseComparator));
-		const result3 = time('sort of 3M', () => sort(multiplesOf3, reverseComparator));
+		const result1 = Timer.time('sort', () => sort(multiplesOf1, reverseComparator));
+		const result2 = Timer.time('sort', () => sort(multiplesOf2, reverseComparator));
+		const result3 = Timer.time('sort', () => sort(multiplesOf3, reverseComparator));
+		Timer.log('sort');
 
-		expect(result1.size).toBe(10_000_000);
-		expect(result2.size).toBe(5_000_000);
-		expect(result3.size).toBe(3_333_333);
+		expect(result1.size).toBe(15_000_000);
+		expect(result2.size).toBe(7_500_000);
+		expect(result3.size).toBe(5_000_000);
 	});
 });


### PR DESCRIPTION
Replaced all `forEach` calls with imperative `for .. of` loops. These replacements happened in the `difference`, `intersection`, & `union` functions, all within the `operations` directory.

Unlike the rewriting of `xor` for #20, which cut down runtime by up to 50%, these `forEach` replacements only changed the total running time of each function on my machine by around 5%.

Moreover, each test run was handled at the whims of my machine's moment-to-moment cpu availability. To make the performance tests as robust as possible, I increased the Set size limit from `10 Mil` to `15 Mil`. However, there is a bug in V8 that causes sets of `size > 16,777,216` to error on `add` calls. So I could not reasonably increase this testing limit much higher.