### PR TITLE
added many sets to scale tests

### DIFF
--- a/test/constants/multiples.model.ts
+++ b/test/constants/multiples.model.ts
@@ -70,7 +70,7 @@ export abstract class Multiples {
 				{ length: quantity },
 				(_, setIndex) => new Set<number>(Array.from(
 					{ length: size },
-					(_, index) => index + (offset ? (setIndex * size) : 0),
+					(__, index) => index + (offset ? (setIndex * size) : 0),
 				)),
 			));
 	}

--- a/test/constants/multiples.model.ts
+++ b/test/constants/multiples.model.ts
@@ -68,9 +68,9 @@ export abstract class Multiples {
 		return Timer.time('copying many', () =>
 			Array.from(
 				{ length: quantity },
-				(_, setIndex) => new Set<number>(Array.from(
+				(_1, setIndex) => new Set<number>(Array.from(
 					{ length: size },
-					(__, index) => index + (offset ? (setIndex * size) : 0),
+					(_2, index) => index + (offset ? (setIndex * size) : 0),
 				)),
 			));
 	}

--- a/test/constants/multiples.model.ts
+++ b/test/constants/multiples.model.ts
@@ -16,6 +16,10 @@ export abstract class Multiples {
 	private static _of1?: ReadonlySet<number>;
 	private static _of2?: ReadonlySet<number>;
 	private static _of3?: ReadonlySet<number>;
+	private static _someEquivalent?: ReadonlyArray<ReadonlySet<number>>;
+	private static _manyEquivalent?: ReadonlyArray<ReadonlySet<number>>;
+	private static _someDisjoint?: ReadonlyArray<ReadonlySet<number>>;
+	private static _manyDisjoint?: ReadonlyArray<ReadonlySet<number>>;
 
 	public static get of1(): ReadonlySet<number> {
 		if (typeof this._of1 === 'undefined') this._of1 = Multiples.of(1, 15_000_000);
@@ -32,11 +36,42 @@ export abstract class Multiples {
 		return this._of3;
 	}
 
-	private static of(factor: number, size: number): ReadonlySet<number> {
+	public static get someEquivalent(): ReadonlyArray<ReadonlySet<number>> {
+		if (typeof this._someEquivalent === 'undefined') this._someEquivalent = Multiples.manyOf(100, 100_000);
+		return this._someEquivalent;
+	}
+
+	public static get manyEquivalent(): ReadonlyArray<ReadonlySet<number>> {
+		if (typeof this._manyEquivalent === 'undefined') this._manyEquivalent = Multiples.manyOf(10_000, 1_000);
+		return this._manyEquivalent;
+	}
+
+	public static get someDisjoint(): ReadonlyArray<ReadonlySet<number>> {
+		if (typeof this._someDisjoint === 'undefined') this._someDisjoint = Multiples.manyOf(100, 100_000, true);
+		return this._someDisjoint;
+	}
+
+	public static get manyDisjoint(): ReadonlyArray<ReadonlySet<number>> {
+		if (typeof this._manyDisjoint === 'undefined') this._manyDisjoint = Multiples.manyOf(10_000, 1_000, true);
+		return this._manyDisjoint;
+	}
+
+	private static of(factor: number, size: number, offset = 0): ReadonlySet<number> {
 		return Timer.time('copying multiples', () =>
 			new Set<number>(Array.from(
 				{ length: size },
-				(_, index) => index * factor),
+				(_, index) => (index * factor) + offset),
+			));
+	}
+
+	private static manyOf(quantity: number, size: number, offset = false): ReadonlyArray<ReadonlySet<number>> {
+		return Timer.time('copying many', () =>
+			Array.from(
+				{ length: quantity },
+				(_, setIndex) => new Set<number>(Array.from(
+					{ length: size },
+					(_, index) => index + (offset ? (setIndex * size) : 0),
+				)),
 			));
 	}
 }

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -8,134 +8,204 @@ describe('Scale Tests', () => {
 	const multiplesOf1 = Multiples.of1;
 	const multiplesOf2 = Multiples.of2;
 	const multiplesOf3 = Multiples.of3;
-	const padding = 28;
+
+	const someEquivalent = Multiples.someEquivalent;
+	const manyEquivalent = Multiples.manyEquivalent;
+	const someDisjoint = Multiples.someDisjoint;
+	const manyDisjoint = Multiples.manyDisjoint;
+
+	const padding = 32;
 	Timer.logAll();
 
 	describe('Operations', () => {
 		describe('difference', () => {
 			it('difference(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('difference', () => difference(multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('difference', () => difference(multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('difference(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(0);
+				const result = Timer.time('difference', () => difference(multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(0);
 			});
 			it('difference(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('difference(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('difference', () => difference(multiplesOf2, multiplesOf1));
-				expect(result3.size).toBe(0);
+				const result = Timer.time('difference', () => difference(multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(0);
 			});
 			it('difference(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(0);
+				const result = Timer.time('difference', () => difference(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(0);
 			});
 			it('difference(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4.size).toBe(5_000_000);
+				const result = Timer.time('difference', () => difference(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result.size).toBe(5_000_000);
 			});
 			it('difference(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('difference', () => difference(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5.size).toBe(0);
+				const result = Timer.time('difference', () => difference(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(0);
+			});
+			it('difference(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('difference', () => difference(...someEquivalent));
+				expect(result.size).toBe(0);
+			});
+			it('difference(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('difference', () => difference(...manyEquivalent));
+				expect(result.size).toBe(0);
+			});
+			it('difference(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('difference', () => difference(...someDisjoint));
+				expect(result.size).toBe(100_000);
+			});
+			it('difference(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('difference', () => difference(...manyDisjoint));
+				expect(result.size).toBe(1_000);
 			});
 			afterAll(() => Timer.log('difference'));
 		});
 
 		describe('intersection', () => {
 			it('intersection(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('intersection', () => intersection(multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('intersection(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('intersection(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('intersection(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('intersection', () => intersection(multiplesOf2, multiplesOf1));
-				expect(result3.size).toBe(7_500_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('intersection(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('intersection(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4.size).toBe(2_500_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result.size).toBe(2_500_000);
 			});
 			it('intersection(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('intersection', () => intersection(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5.size).toBe(2_500_000);
+				const result = Timer.time('intersection', () => intersection(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(2_500_000);
+			});
+			it('intersection(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('intersection', () => intersection(...someEquivalent));
+				expect(result.size).toBe(100_000);
+			});
+			it('intersection(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('intersection', () => intersection(...manyEquivalent));
+				expect(result.size).toBe(1_000);
+			});
+			it('intersection(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('intersection', () => intersection(...someDisjoint));
+				expect(result.size).toBe(0);
+			});
+			it('intersection(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('intersection', () => intersection(...manyDisjoint));
+				expect(result.size).toBe(0);
 			});
 			afterAll(() => Timer.log('intersection'));
 		});
 
 		describe('union', () => {
 			it('union(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('union', () => union(multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('union', () => union(multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('union', () => union(multiplesOf1, multiplesOf2));
-				expect(result2.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf1, multiplesOf2));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('union', () => union(multiplesOf2, multiplesOf1));
-				expect(result3.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('union', () => union(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('union', () => union(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('union(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('union', () => union(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5.size).toBe(15_000_000);
+				const result = Timer.time('union', () => union(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(15_000_000);
+			});
+			it('union(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('union', () => union(...someEquivalent));
+				expect(result.size).toBe(100_000);
+			});
+			it('union(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('union', () => union(...manyEquivalent));
+				expect(result.size).toBe(1_000);
+			});
+			it('union(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('union', () => union(...someDisjoint));
+				expect(result.size).toBe(10_000_000);
+			});
+			it('union(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('union', () => union(...manyDisjoint));
+				expect(result.size).toBe(10_000_000);
 			});
 			afterAll(() => Timer.log('union'));
 		});
 
 		describe('xor', () => {
 			it('xor(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('xor', () => xor(multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('xor', () => xor(multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('xor(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(0);
+				const result = Timer.time('xor', () => xor(multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(0);
 			});
 			it('xor(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('xor(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('xor', () => xor(multiplesOf2, multiplesOf1));
-				expect(result3.size).toBe(7_500_000);
+				const result = Timer.time('xor', () => xor(multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('xor(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1.size).toBe(0);
+				const result = Timer.time('xor', () => xor(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result.size).toBe(0);
 			});
 			it('xor(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4.size).toBe(5_000_000);
+				const result = Timer.time('xor', () => xor(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result.size).toBe(5_000_000);
 			});
 			it('xor(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('xor', () => xor(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5.size).toBe(5_000_000);
+				const result = Timer.time('xor', () => xor(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result.size).toBe(5_000_000);
+			});
+			it('xor(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('xor', () => xor(...someEquivalent));
+				expect(result.size).toBe(0);
+			});
+			it('xor(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('xor', () => xor(...manyEquivalent));
+				expect(result.size).toBe(0);
+			});
+			it('xor(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('xor', () => xor(...someDisjoint));
+				expect(result.size).toBe(10_000_000);
+			});
+			it('xor(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('xor', () => xor(...manyDisjoint));
+				expect(result.size).toBe(10_000_000);
 			});
 			afterAll(() => Timer.log('xor'));
 		});
@@ -144,128 +214,192 @@ describe('Scale Tests', () => {
 	describe('Comparisons', () => {
 		describe('disjoint', () => {
 			it('disjoint(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('disjoint', () => disjoint(multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('disjoint(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf1));
-				expect(result1).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf1));
+				expect(result).toBe(false);
 			});
 			it('disjoint(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2));
-				expect(result2).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2));
+				expect(result).toBe(false);
 			});
 			it('disjoint(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('disjoint', () => disjoint(multiplesOf2, multiplesOf1));
-				expect(result3).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
 			});
 			it('disjoint(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result).toBe(false);
 			});
 			it('disjoint(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result).toBe(false);
 			});
 			it('disjoint(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('disjoint', () => disjoint(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5).toBe(false);
+				const result = Timer.time('disjoint', () => disjoint(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('disjoint(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('disjoint', () => disjoint(...someEquivalent));
+				expect(result).toBe(false);
+			});
+			it('disjoint(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('disjoint', () => disjoint(...manyEquivalent));
+				expect(result).toBe(false);
+			});
+			it('disjoint(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('disjoint', () => disjoint(...someDisjoint));
+				expect(result).toBe(true);
+			});
+			it('disjoint(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('disjoint', () => disjoint(...manyDisjoint));
+				expect(result).toBe(true);
 			});
 			afterAll(() => Timer.log('disjoint'));
 		});
 
 		describe('equivalence', () => {
 			it('equivalence(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('equivalence', () => equivalence(multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('equivalence(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('equivalence(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2));
-				expect(result2).toBe(false);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2));
+				expect(result).toBe(false);
 			});
 			it('equivalence(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('equivalence', () => equivalence(multiplesOf2, multiplesOf1));
-				expect(result3).toBe(false);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
 			});
 			it('equivalence(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('equivalence(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4).toBe(false);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result).toBe(false);
 			});
 			it('equivalence(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('equivalence', () => equivalence(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5).toBe(false);
+				const result = Timer.time('equivalence', () => equivalence(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('equivalence(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('equivalence', () => equivalence(...someEquivalent));
+				expect(result).toBe(true);
+			});
+			it('equivalence(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('equivalence', () => equivalence(...manyEquivalent));
+				expect(result).toBe(true);
+			});
+			it('equivalence(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('equivalence', () => equivalence(...someDisjoint));
+				expect(result).toBe(false);
+			});
+			it('equivalence(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('equivalence', () => equivalence(...manyDisjoint));
+				expect(result).toBe(false);
 			});
 			afterAll(() => Timer.log('equivalence'));
 		});
 
 		describe('subset', () => {
 			it('subset(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('subset', () => subset(multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('subset', () => subset(multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('subset(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('subset', () => subset(multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('subset(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2));
-				expect(result2).toBe(false);
+				const result = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2));
+				expect(result).toBe(false);
 			});
 			it('subset(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('subset', () => subset(multiplesOf2, multiplesOf1));
-				expect(result3).toBe(true);
+				const result = Timer.time('subset', () => subset(multiplesOf2, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('subset(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('subset', () => subset(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('subset(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4).toBe(false);
+				const result = Timer.time('subset', () => subset(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result).toBe(false);
 			});
 			it('subset(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('subset', () => subset(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5).toBe(false);
+				const result = Timer.time('subset', () => subset(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('subset(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('subset', () => subset(...someEquivalent));
+				expect(result).toBe(true);
+			});
+			it('subset(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('subset', () => subset(...manyEquivalent));
+				expect(result).toBe(true);
+			});
+			it('subset(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('subset', () => subset(...someDisjoint));
+				expect(result).toBe(false);
+			});
+			it('subset(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('subset', () => subset(...manyDisjoint));
+				expect(result).toBe(false);
 			});
 			afterAll(() => Timer.log('subset'));
 		});
 
 		describe('superset', () => {
 			it('superset(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('superset', () => superset(multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('superset', () => superset(multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('superset(of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('superset', () => superset(multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('superset(of1, of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2));
-				expect(result2).toBe(true);
+				const result = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2));
+				expect(result).toBe(true);
 			});
 			it('superset(of2, of1):'.padEnd(padding), () => {
-				const result3 = Timer.time('superset', () => superset(multiplesOf2, multiplesOf1));
-				expect(result3).toBe(false);
+				const result = Timer.time('superset', () => superset(multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
 			});
 			it('superset(of1, of1, of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf1, multiplesOf1));
-				expect(result1).toBe(true);
+				const result = Timer.time('superset', () => superset(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result).toBe(true);
 			});
 			it('superset(of1, of2, of3):'.padEnd(padding), () => {
-				const result4 = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2, multiplesOf3));
-				expect(result4).toBe(true);
+				const result = Timer.time('superset', () => superset(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result).toBe(true);
 			});
 			it('superset(of3, of2, of1):'.padEnd(padding), () => {
-				const result5 = Timer.time('superset', () => superset(multiplesOf3, multiplesOf2, multiplesOf1));
-				expect(result5).toBe(false);
+				const result = Timer.time('superset', () => superset(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('superset(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('superset', () => superset(...someEquivalent));
+				expect(result).toBe(true);
+			});
+			it('superset(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('superset', () => superset(...manyEquivalent));
+				expect(result).toBe(true);
+			});
+			it('superset(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('superset', () => superset(...someDisjoint));
+				expect(result).toBe(false);
+			});
+			it('superset(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('superset', () => superset(...manyDisjoint));
+				expect(result).toBe(false);
 			});
 			afterAll(() => Timer.log('superset'));
 		});
@@ -274,40 +408,40 @@ describe('Scale Tests', () => {
 	describe('Ordering', () => {
 		describe('sort', () => {
 			it('sort(of1):'.padEnd(padding), () => {
-				const result1 = Timer.time('sort', () => sort(multiplesOf1));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf1));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('sort(of1, default):'.padEnd(padding), () => {
-				const result1 = Timer.time('sort', () => sort(multiplesOf1, defaultComparator));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf1, defaultComparator));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('sort(of1, reverse):'.padEnd(padding), () => {
-				const result1 = Timer.time('sort', () => sort(multiplesOf1, reverseComparator));
-				expect(result1.size).toBe(15_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf1, reverseComparator));
+				expect(result.size).toBe(15_000_000);
 			});
 			it('sort(of2):'.padEnd(padding), () => {
-				const result2 = Timer.time('sort', () => sort(multiplesOf2));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('sort', () => sort(multiplesOf2));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('sort(of2, default):'.padEnd(padding), () => {
-				const result2 = Timer.time('sort', () => sort(multiplesOf2, defaultComparator));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('sort', () => sort(multiplesOf2, defaultComparator));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('sort(of2, reverse):'.padEnd(padding), () => {
-				const result2 = Timer.time('sort', () => sort(multiplesOf2, reverseComparator));
-				expect(result2.size).toBe(7_500_000);
+				const result = Timer.time('sort', () => sort(multiplesOf2, reverseComparator));
+				expect(result.size).toBe(7_500_000);
 			});
 			it('sort(of3):'.padEnd(padding), () => {
-				const result3 = Timer.time('sort', () => sort(multiplesOf3));
-				expect(result3.size).toBe(5_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf3));
+				expect(result.size).toBe(5_000_000);
 			});
 			it('sort(of3, default):'.padEnd(padding), () => {
-				const result3 = Timer.time('sort', () => sort(multiplesOf3, defaultComparator));
-				expect(result3.size).toBe(5_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf3, defaultComparator));
+				expect(result.size).toBe(5_000_000);
 			});
 			it('sort(of3, reverse):'.padEnd(padding), () => {
-				const result3 = Timer.time('sort', () => sort(multiplesOf3, reverseComparator));
-				expect(result3.size).toBe(5_000_000);
+				const result = Timer.time('sort', () => sort(multiplesOf3, reverseComparator));
+				expect(result.size).toBe(5_000_000);
 			});
 			afterAll(() => Timer.log('sort'));
 		});


### PR DESCRIPTION
Added 4 tests to each scale test suite, based on the following configurations:
1. `100` equivalent sets, each containing `100_000` values.
2. `10_000` equivalent sets, each containing `1_000` values.
3. `100` disjoint sets, each containing `100_000` values.
4. `10_000` disjoint sets, each containing `1_000` values.