### PR TITLE
improved intersection performance

### DIFF
--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -12,15 +12,11 @@ export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	let result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
-		const _intersection = new Set<T>();
-
-		for (const value of sets[index]!) {
-			if (result.has(value)) {
-				_intersection.add(value);
+		for (const value of result) {
+			if (!sets[index]!.has(value)) {
+				result.delete(value);
 			}
 		}
-
-		result = _intersection;
 	}
 
 	return result as ReadonlySet<T> as S;

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -9,7 +9,7 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	let result = new Set<T>(sets[0] ?? new Set<T>());
+	const result = new Set<T>(sets[0] ?? new Set<T>());
 
 	for (let index = 1; index < sets.length; index++) {
 		for (const value of result) {


### PR DESCRIPTION
# description:
`intersection` was originally written by generating a `new Set()` with the intersected values for each provided set. Then, loop over the values in each provided set, checking against the former result.

This rewrite changes `intersection` to only generate a single `new Set()` at the outset. Then, loop over the values in that `result` once for each provided set, checking against that provided set.

So, for instance. If after the first iteration there are 0 values in the `result` set, then `intersection` will stop checking for values in further result sets, and return immediately. This is what we see happen in `intersection(...someDisjoint)` test, where the run time is shown to be reduced by over 99%.

And we see this performance gain in less user optimized versions of the horizontal scale tests as well. The `intersection(...equivalent)` tests are highly user un-optimized, but they still see performance improvements of around 60%. In these cases, the number of iterations per set remains maximized over time, no performance gain there. But we are not creating a `new Set()` instance per input set, and that is where we see performance gains.

**_Caveat:_** you will notice that the `intersection(of1, of2)` & `intersection(of1, of2, of3)` actually increased in run time by ~20% and ~15% respectively. While their `intersection(of2, of1)` & `intersection(of3, of2, of1)` counterparts decreased in run time by ~50%. This particular case, where the first input value is by far the largest, is the only instance where this version of the code turns out to be less performant than the original. We see this, especially with respect to small # of input sets, because generating that large result set and then removing most values from it takes longer than generating multiple result sets.

# performance metrics:

<details>
<summary><h2 style="display: inline">[original] raw data:</h3></summary>

### [original] vertical scale tests:
|              | intersection(of1) | intersection(of1, of1) | intersection(of1, of2) | intersection(of2, of1) | intersection(of1, of1, of1) | intersection(of1, of2, of3) | intersection(of3, of2, of1) |
|:-------------|:------------------|:-----------------------|:-----------------------|:-----------------------|:----------------------------|:----------------------------|:----------------------------|
| test 0:      | 4839.021ms        | 11685.678ms            | 7597.830ms             | 6614.592ms             | 16769.361ms                 | 9229.892ms                  | 6110.954ms                  |
| test 1:      | 4875.544ms        | 11367.991ms            | 7826.475ms             | 6013.343ms             | 16582.626ms                 | 9390.927ms                  | 6191.612ms                  |
| test 2:      | 5035.450ms        | 11457.707ms            | 7797.889ms             | 6490.443ms             | 17301.781ms                 | 9311.935ms                  | 5832.729ms                  |
| test 3:      | 4618.940ms        | 10964.712ms            | 7692.446ms             | 6299.759ms             | 16614.722ms                 | 9493.531ms                  | 6199.848ms                  |
| test 4:      | 5113.103ms        | 11282.294ms            | 7816.781ms             | 6620.598ms             | 16377.308ms                 | 8784.848ms                  | 5839.951ms                  |
| test 5:      | 4723.494ms        | 10536.138ms            | 7243.139ms             | 5958.790ms             | 15645.861ms                 | 9035.845ms                  | 6237.262ms                  |
| test 6:      | 5107.191ms        | 11298.766ms            | 7877.921ms             | 6409.295ms             | 16379.414ms                 | 9470.107ms                  | 6237.547ms                  |
| test 7:      | 4926.404ms        | 11293.224ms            | 7681.512ms             | 6343.365ms             | 16886.795ms                 | 8711.387ms                  | 5989.250ms                  |
| test 8:      | 5037.056ms        | 11232.390ms            | 7725.641ms             | 6372.294ms             | 15748.793ms                 | 8810.258ms                  | 5692.923ms                  |
| test 9:      | 4800.157ms        | 10986.431ms            | 7945.835ms             | 6414.934ms             | 16020.806ms                 | 9591.335ms                  | 6185.079ms                  |
|              |                   |                        |                        |                        |                             |                             |                             |
| **average:** | **4907.636ms**    | **11210.533ms**        | **7720.547ms**         | **6353.741ms**         | **16432.747ms**             | **9183.007ms**              | **6051.716ms**              |

### [original] horizontal scale tests:
|              | intersection(...someEquivalent) | intersection(...manyEquivalent) | intersection(...someDisjoint) | intersection(...manyDisjoint) |
|:-------------|:--------------------------------|:--------------------------------|:------------------------------|:------------------------------|
| test 0:      | 1738.267ms                      | 764.591ms                       | 177.354ms                     | 148.686ms                     |
| test 1:      | 1603.753ms                      | 799.900ms                       | 188.816ms                     | 191.168ms                     |
| test 2:      | 1409.055ms                      | 670.028ms                       | 173.934ms                     | 164.016ms                     |
| test 3:      | 1471.549ms                      | 693.705ms                       | 172.137ms                     | 195.383ms                     |
| test 4:      | 1433.647ms                      | 676.126ms                       | 145.092ms                     | 148.604ms                     |
| test 5:      | 1652.631ms                      | 708.243ms                       | 187.863ms                     | 186.836ms                     |
| test 6:      | 1716.842ms                      | 726.963ms                       | 170.072ms                     | 145.402ms                     |
| test 7:      | 1646.944ms                      | 678.907ms                       | 171.235ms                     | 155.114ms                     |
| test 8:      | 1431.737ms                      | 673.867ms                       | 157.429ms                     | 154.264ms                     |
| test 9:      | 1580.712ms                      | 717.585ms                       | 176.644ms                     | 173.108ms                     |
|              |                                 |                                 |                               |                               |
| **average:** | **1568.514ms**                  | **710.992ms**                   | **172.058ms**                 | **166.258ms**                 |
</details>

<details>
<summary><h2 style="display: inline">[rewrite] raw data:</h3></summary>

### [rewrite] vertical scale tests:
|              | intersection(of1) | intersection(of1, of1) | intersection(of1, of2) | intersection(of2, of1) | intersection(of1, of1, of1) | intersection(of1, of2, of3) | intersection(of3, of2, of1) |
|:-------------|:------------------|:-----------------------|:-----------------------|:-----------------------|:----------------------------|:----------------------------|:----------------------------|
| test 0:      | 4555.779ms        | 7640.710ms             | 8785.039ms             | 3066.465ms             | 8410.291ms                  | 10169.128ms                 | 2990.492ms                  |
| test 1:      | 4871.777ms        | 8079.638ms             | 9168.692ms             | 3281.017ms             | 8761.294ms                  | 10667.483ms                 | 3355.688ms                  |
| test 2:      | 4991.084ms        | 8366.008ms             | 9573.297ms             | 3473.680ms             | 9239.303ms                  | 11728.399ms                 | 3160.270ms                  |
| test 3:      | 5449.948ms        | 8567.496ms             | 9097.109ms             | 3107.934ms             | 8312.837ms                  | 10234.638ms                 | 3019.690ms                  |
| test 4:      | 5193.160ms        | 8197.324ms             | 9454.645ms             | 3078.274ms             | 8386.360ms                  | 10355.599ms                 | 3112.314ms                  |
| test 5:      | 4613.356ms        | 7729.680ms             | 8863.799ms             | 3108.929ms             | 8635.083ms                  | 10193.167ms                 | 2920.325ms                  |
| test 6:      | 4948.408ms        | 8211.730ms             | 9750.572ms             | 3404.651ms             | 9020.828ms                  | 10869.188ms                 | 2894.175ms                  |
| test 7:      | 4562.452ms        | 7589.012ms             | 9197.461ms             | 3060.763ms             | 8274.839ms                  | 10315.096ms                 | 3301.630ms                  |
| test 8:      | 5115.621ms        | 8255.933ms             | 9894.559ms             | 3194.926ms             | 8612.461ms                  | 10687.761ms                 | 3145.431ms                  |
| test 9:      | 4867.068ms        | 7833.073ms             | 8788.805ms             | 3102.710ms             | 8475.651ms                  | 10544.807ms                 | 3050.051ms                  |
|              |                   |                        |                        |                        |                             |                             |                             |
| **average:** | **4916.865ms**    | **8047.060ms**         | **9257.398ms**         | **3187.935ms**         | **8612.895ms**              | **10576.527ms**             | **3095.007ms**              |

### [rewrite] horizontal scale tests:
|              | intersection(...someEquivalent) | intersection(...manyEquivalent) | intersection(...someDisjoint) | intersection(...manyDisjoint) |
|:-------------|---------------------------------|:--------------------------------|:------------------------------|:------------------------------|
| test 0:      | 471.294ms                       | 289.215ms                       | 24.590ms                      | 0.360ms                       |
| test 1:      | 672.560ms                       | 288.405ms                       | 31.625ms                      | 0.682ms                       |
| test 2:      | 525.322ms                       | 301.466ms                       | 29.394ms                      | 0.258ms                       |
| test 3:      | 461.245ms                       | 272.099ms                       | 23.856ms                      | 0.455ms                       |
| test 4:      | 480.698ms                       | 309.567ms                       | 26.803ms                      | 0.246ms                       |
| test 5:      | 464.730ms                       | 289.165ms                       | 25.846ms                      | 0.255ms                       |
| test 6:      | 471.853ms                       | 288.534ms                       | 28.462ms                      | 0.336ms                       |
| test 7:      | 477.707ms                       | 284.619ms                       | 27.297ms                      | 0.273ms                       |
| test 8:      | 494.756ms                       | 296.606ms                       | 40.487ms                      | 0.434ms                       |
| test 9:      | 523.979ms                       | 298.529ms                       | 24.977ms                      | 0.447ms                       |
|              |                                 |                                 |                               |                               |
| **average:** | **504.414ms**                   | **291.821ms**                   | **28.334ms**                  | **0.375ms**                   |
</details>

## `intersection` performance improvements:

### [performance change] vertical scale tests:
|                   | intersection(of1) | intersection(of1, of1) | intersection(of1, of2) | intersection(of2, of1) | intersection(of1, of1, of1) | intersection(of1, of2, of3) | intersection(of3, of2, of1) |
|:------------------|:------------------|:-----------------------|:-----------------------|:-----------------------|:----------------------------|:----------------------------|:----------------------------|
| original average: | 4907.636ms        | 11210.533ms            | 7720.547ms             | 6353.741ms             | 16432.747ms                 | 9183.007ms                  | 6051.716ms                  |
| rewrite average:  | 4916.865ms        | 8047.060ms             | 9257.398ms             | 3187.935ms             | 8612.895ms                  | 10576.527ms                 | 3095.007ms                  |
| **change:**       | **+0.19%**        | **-28.22%**            | **+19.91%**            | **-49.83%**            | **-47.59%**                 | **+15.17%**                 | **-48.86%**                 |

### [performance change] horizontal scale tests:
|                   | intersection(...someEquivalent) | intersection(...manyEquivalent) | intersection(...someDisjoint) | intersection(...manyDisjoint) |
|:------------------|:--------------------------------|:--------------------------------|:------------------------------|:------------------------------|
| original average: | 1568.514ms                      | 710.992ms                       | 172.058ms                     | 166.258ms                     |
| rewrite average:  | 504.414ms                       | 291.821ms                       | 28.334ms                      | 0.375ms                       |
| **change:**       | **-67.84%**                     | **-58.96%**                     | **-83.53%**                   | **-99.77%**                   |
