### PR TITLE
removed nullish coalescing

### DIFF
--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -11,7 +11,7 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∖ B ≔ { x : (x ∈ A) ∧ (x ∉ B) }
  */
 export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0] ?? new Set<T>());
+	const result = new Set<T>(sets[0]);
 
 	for (let index = 1; index < sets.length; index++) {
 		for (const value of sets[index]!) {

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -9,7 +9,7 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0] ?? new Set<T>());
+	const result = new Set<T>(sets[0]);
 
 	for (let index = 1; index < sets.length; index++) {
 		for (const value of result) {

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -9,7 +9,7 @@ export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∪ B ≔ { x : (x ∈ A) ∨ (x ∈ B) }
  */
 export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0] ?? new Set<T>());
+	const result = new Set<T>(sets[0]);
 
 	for (let index = 1; index < sets.length; index++) {
 		for (const value of sets[index]!) {

--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -11,7 +11,7 @@ export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∆ B ≔ { x : (x ∈ A) ⊕ (x ∈ B) }
  */
 export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0] ?? new Set<T>());
+	const result = new Set<T>(sets[0]);
 	const reusedValues = new Set<T>();
 
 	for (let index = 1; index < sets.length; index++) {


### PR DESCRIPTION
After some further testing, when there is no value provided at `sets[0]`, the resulting `new Set(undefined)` behaves equivalently to `new Set()`: it produces an empty set, without throwing an error.

So I have removed this instance of nullish coalescing on the resulting `new Set(undefined ?? new Set())`. In favor of simpler and cleaner code.