### PR TITLE
refactored funcitons to use `sets.shift()` & `for .. of`

### DIFF
--- a/src/comparisons/disjoint.function.ts
+++ b/src/comparisons/disjoint.function.ts
@@ -16,8 +16,8 @@ export function disjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 	}
 
 	const allElements = new Set<T>(sets.shift());
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			if (allElements.has(element)) {
 				return false;
 			} else {

--- a/src/comparisons/disjoint.function.ts
+++ b/src/comparisons/disjoint.function.ts
@@ -15,8 +15,8 @@ export function disjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 		return true;
 	}
 
-	const allElements = new Set<T>(sets[0]);
-	for (let index = 1; index < sets.length; index++) {
+	const allElements = new Set<T>(sets.shift());
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
 			if (allElements.has(element)) {
 				return false;

--- a/src/comparisons/equivalence.function.ts
+++ b/src/comparisons/equivalence.function.ts
@@ -25,9 +25,10 @@ export function equivalence<T, S extends ReadonlySet<T>>(...sets: S[]): boolean 
 		return false;
 	}
 
-	for (const element of sets[0]!) {
-		for (let index = 1; index < sets.length; index++) {
-			if (!sets[index]?.has(element)) {
+	const primarySet = sets.shift()!;
+	for (const element of primarySet!) {
+		for (let index = 0; index < sets.length; ++index) {
+			if (!sets[index]!.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/equivalence.function.ts
+++ b/src/comparisons/equivalence.function.ts
@@ -26,9 +26,9 @@ export function equivalence<T, S extends ReadonlySet<T>>(...sets: S[]): boolean 
 	}
 
 	const primarySet = sets.shift()!;
-	for (const element of primarySet!) {
-		for (let index = 0; index < sets.length; ++index) {
-			if (!sets[index]!.has(element)) {
+	for (const element of primarySet) {
+		for (const set of sets) {
+			if (!set.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/proper-subset.function.ts
+++ b/src/comparisons/proper-subset.function.ts
@@ -27,8 +27,8 @@ export function properSubset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean
 
 	const primarySet = sets.shift()!;
 	for (const element of primarySet) {
-		for (let index = 0; index < sets.length; ++index) {
-			if (!sets[index]!.has(element)) {
+		for (const set of sets) {
+			if (!set.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/proper-subset.function.ts
+++ b/src/comparisons/proper-subset.function.ts
@@ -25,9 +25,10 @@ export function properSubset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean
 		return false;
 	}
 
-	for (const element of sets[0]!) {
-		for (let index = 1; index < sets.length; index++) {
-			if (!sets[index]?.has(element)) {
+	const primarySet = sets.shift()!;
+	for (const element of primarySet) {
+		for (let index = 0; index < sets.length; ++index) {
+			if (!sets[index]!.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/proper-superset.function.ts
+++ b/src/comparisons/proper-superset.function.ts
@@ -25,9 +25,10 @@ export function properSuperset<T, S extends ReadonlySet<T>>(...sets: S[]): boole
 		return false;
 	}
 
-	for (let index = 1; index < sets.length; index++) {
+	const primarySet = sets.shift()!;
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
-			if (!sets[0]?.has(element)) {
+			if (!primarySet.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/proper-superset.function.ts
+++ b/src/comparisons/proper-superset.function.ts
@@ -26,8 +26,8 @@ export function properSuperset<T, S extends ReadonlySet<T>>(...sets: S[]): boole
 	}
 
 	const primarySet = sets.shift()!;
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			if (!primarySet.has(element)) {
 				return false;
 			}

--- a/src/comparisons/subset.function.ts
+++ b/src/comparisons/subset.function.ts
@@ -24,9 +24,10 @@ export function subset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 		return false;
 	}
 
-	for (const element of sets[0]!) {
-		for (let index = 1; index < sets.length; index++) {
-			if (!sets[index]?.has(element)) {
+	const primarySet = sets.shift()!;
+	for (const element of primarySet) {
+		for (let index = 0; index < sets.length; ++index) {
+			if (!sets[index]!.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/subset.function.ts
+++ b/src/comparisons/subset.function.ts
@@ -26,8 +26,8 @@ export function subset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 
 	const primarySet = sets.shift()!;
 	for (const element of primarySet) {
-		for (let index = 0; index < sets.length; ++index) {
-			if (!sets[index]!.has(element)) {
+		for (const set of sets) {
+			if (!set.has(element)) {
 				return false;
 			}
 		}

--- a/src/comparisons/superset.function.ts
+++ b/src/comparisons/superset.function.ts
@@ -27,8 +27,8 @@ export function superset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 	}
 
 	const primarySet = sets.shift()!;
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			if (!primarySet.has(element)) {
 				return false;
 			}

--- a/src/comparisons/superset.function.ts
+++ b/src/comparisons/superset.function.ts
@@ -26,9 +26,10 @@ export function superset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 		return false;
 	}
 
-	for (let index = 1; index < sets.length; index++) {
+	const primarySet = sets.shift()!;
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
-			if (!sets[0]?.has(element)) {
+			if (!primarySet.has(element)) {
 				return false;
 			}
 		}

--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -11,13 +11,13 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∖ B ≔ { x : (x ∈ A) ∧ (x ∉ B) }
  */
 export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0]);
+	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 1; index < sets.length; index++) {
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
-			result.delete(element);
+			resultSet.delete(element);
 		}
 	}
 
-	return result as ReadonlySet<T> as S;
+	return resultSet as ReadonlySet<T> as S;
 }

--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -13,8 +13,8 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			resultSet.delete(element);
 		}
 	}

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -9,15 +9,15 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0]);
+	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 1; index < sets.length; index++) {
-		for (const element of result) {
+	for (let index = 0; index < sets.length; ++index) {
+		for (const element of resultSet) {
 			if (!sets[index]!.has(element)) {
-				result.delete(element);
+				resultSet.delete(element);
 			}
 		}
 	}
 
-	return result as ReadonlySet<T> as S;
+	return resultSet as ReadonlySet<T> as S;
 }

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -11,9 +11,9 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 0; index < sets.length; ++index) {
+	for (const set of sets) {
 		for (const element of resultSet) {
-			if (!sets[index]!.has(element)) {
+			if (!set.has(element)) {
 				resultSet.delete(element);
 			}
 		}

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -9,13 +9,13 @@ export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∪ B ≔ { x : (x ∈ A) ∨ (x ∈ B) }
  */
 export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0]);
+	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 1; index < sets.length; index++) {
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
-			result.add(element);
+			resultSet.add(element);
 		}
 	}
 
-	return result as ReadonlySet<T> as S;
+	return resultSet as ReadonlySet<T> as S;
 }

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -11,8 +11,8 @@ export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const resultSet = new Set<T>(sets.shift());
 
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			resultSet.add(element);
 		}
 	}

--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -14,8 +14,8 @@ export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	const resultSet = new Set<T>(sets.shift());
 	const reusedElements = new Set<T>();
 
-	for (let index = 0; index < sets.length; ++index) {
-		for (const element of sets[index]!) {
+	for (const set of sets) {
+		for (const element of set) {
 			if (resultSet.has(element)) {
 				resultSet.delete(element);
 				reusedElements.add(element);

--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -11,19 +11,19 @@ export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∆ B ≔ { x : (x ∈ A) ⊕ (x ∈ B) }
  */
 export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const result = new Set<T>(sets[0]);
+	const resultSet = new Set<T>(sets.shift());
 	const reusedElements = new Set<T>();
 
-	for (let index = 1; index < sets.length; index++) {
+	for (let index = 0; index < sets.length; ++index) {
 		for (const element of sets[index]!) {
-			if (result.has(element)) {
-				result.delete(element);
+			if (resultSet.has(element)) {
+				resultSet.delete(element);
 				reusedElements.add(element);
 			} else if (!reusedElements.has(element)) {
-				result.add(element);
+				resultSet.add(element);
 			}
 		}
 	}
 
-	return result as ReadonlySet<T> as S;
+	return resultSet as ReadonlySet<T> as S;
 }


### PR DESCRIPTION
## Legibility
I personally find that the resulting code is more legible, using `sets.shift()` in conjunction with `for (const set of sets)`.
As an aside, this code style also removed all necessary usages of nullish coalescing.

## Performance
Moreover, the refactored code resulted in an overall performance improvement of ~11% overall. This is generally due to the fact that we are not fetching `sets[index]` in each loop iteration, in favor of a pre-cached `const set`.

Testing Notes:
- All tests were run on a 2017 Razer Blade Pro, Core i7-7700HQ Processor, 64GB ram.
- All tests were run using the V8 JS engine.
- All timings is in ms

<details>
<summary><h3 style="display: inline">[original] raw data:</h3></summary>

| Original Overall Timing: | time (ms)   |
|--------------------------|-------------|
| Original Run Timing 1    | 306,064.716 |
| Original Run Timing 2    | 320,495.549 |
| Original Run Timing 3    | 320,353.267 |
| Original Run Timing 4    | 324,881.274 |
| Original Run Timing 5    | 298,814.159 |
| Original Average         | 314,121.793 |


| Original Test Timing:                  | function(of1) | function(of1 of1) | function(of1 of2) | function(of2 of1) | function(of1 of1 of1) | function(of1 of2 of3) | function(of3 of2 of1) | function(...someEquivalent) | function(...manyEquivalent) | function(...someDisjoint) | function(...manyDisjoint) |
|----------------------------------------|---------------|-------------------|-------------------|-------------------|-----------------------|-----------------------|-----------------------|-----------------------------|-----------------------------|---------------------------|---------------------------|
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| difference                             | 5,528.537     | 9,281.126         | 6,413.706         | 5,202.763         | 8,655.808             | 7,310.503             | 4,525.348             | 157.412                     | 147.759                     | 518.512                   | 326.498                   |
| difference                             | 5,165.204     | 9,319.900         | 6,352.209         | 5,225.966         | 9,312.768             | 7,924.933             | 5,175.987             | 161.351                     | 127.630                     | 564.634                   | 347.230                   |
| difference                             | 4,971.867     | 8,980.129         | 6,361.118         | 5,185.202         | 8,573.869             | 7,279.279             | 4,944.845             | 161.992                     | 157.714                     | 583.842                   | 333.448                   |
| difference                             | 5,086.717     | 9,639.039         | 6,953.099         | 5,565.336         | 9,386.295             | 7,694.673             | 4,949.082             | 183.770                     | 162.799                     | 648.022                   | 335.219                   |
| difference                             | 5,667.664     | 9,482.243         | 6,431.150         | 5,275.223         | 8,184.738             | 7,379.964             | 4,625.915             | 156.098                     | 136.462                     | 501.327                   | 308.818                   |
| original difference average            | 5,283.998     | 9,340.487         | 6,502.256         | 5,290.898         | 8,822.696             | 7,517.870             | 4,844.235             | 164.125                     | 146.473                     | 563.267                   | 330.243                   |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| intersection                           | 4,728.279     | 7,722.473         | 8,810.480         | 3,119.550         | 8,263.591             | 10,428.028            | 2,968.837             | 469.202                     | 283.654                     | 27.033                    | 0.257                     |
| intersection                           | 4,933.843     | 9,436.174         | 9,850.423         | 3,448.747         | 8,891.150             | 11,830.733            | 3,120.385             | 499.776                     | 299.540                     | 50.966                    | 0.450                     |
| intersection                           | 4,873.496     | 8,643.706         | 9,679.400         | 3,287.866         | 9,520.043             | 12,087.650            | 3,519.241             | 548.949                     | 307.196                     | 32.307                    | 0.322                     |
| intersection                           | 5,048.614     | 8,714.641         | 9,923.594         | 3,427.063         | 9,604.551             | 11,736.987            | 3,417.378             | 507.215                     | 306.311                     | 29.764                    | 0.786                     |
| intersection                           | 4,612.503     | 8,185.622         | 9,630.233         | 3,350.761         | 9,002.574             | 10,948.823            | 3,642.584             | 447.779                     | 290.996                     | 27.026                    | 0.257                     |
| original intersection average          | 4,839.347     | 8,540.523         | 9,578.826         | 3,326.797         | 9,056.382             | 11,406.444            | 3,333.685             | 494.584                     | 297.539                     | 33.419                    | 0.414                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| union                                  | 4,795.467     | 7,062.333         | 6,084.723         | 5,184.707         | 8,877.905             | 6,266.018             | 5,810.776             | 388.479                     | 241.289                     | 2,464.073                 | 2,638.573                 |
| union                                  | 5,117.724     | 7,671.835         | 6,240.681         | 5,487.634         | 9,501.192             | 6,812.853             | 5,753.113             | 532.984                     | 298.962                     | 2,470.075                 | 2,474.088                 |
| union                                  | 5,486.514     | 7,749.413         | 5,983.009         | 5,706.268         | 9,163.675             | 6,657.030             | 5,901.155             | 754.564                     | 252.291                     | 2,748.041                 | 2,968.163                 |
| union                                  | 5,016.722     | 7,625.566         | 6,112.399         | 5,710.951         | 9,713.799             | 7,103.469             | 5,922.020             | 498.116                     | 269.847                     | 2,721.073                 | 2,874.513                 |
| union                                  | 4,614.345     | 7,237.181         | 5,515.699         | 5,146.438         | 9,107.971             | 6,525.618             | 5,785.559             | 411.243                     | 242.027                     | 2,421.232                 | 2,797.015                 |
| original union average                 | 5,006.154     | 7,469.266         | 5,987.302         | 5,447.200         | 9,272.908             | 6,672.998             | 5,834.525             | 517.077                     | 260.883                     | 2,564.899                 | 2,750.470                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| xor                                    | 5,213.459     | 13,255.000        | 8,112.156         | 9,663.168         | 16,079.426            | 10,144.474            | 12,790.923            | 856.500                     | 363.123                     | 3,831.277                 | 3,535.291                 |
| xor                                    | 5,131.879     | 14,043.527        | 8,892.519         | 10,306.754        | 17,900.462            | 11,732.074            | 12,879.764            | 900.448                     | 402.814                     | 3,745.252                 | 3,691.311                 |
| xor                                    | 5,211.524     | 14,650.832        | 8,783.771         | 10,400.013        | 17,190.609            | 11,425.864            | 13,288.162            | 901.185                     | 435.490                     | 3,999.618                 | 3,832.765                 |
| xor                                    | 5,299.869     | 14,638.828        | 8,705.744         | 10,958.786        | 16,693.414            | 11,824.148            | 13,497.853            | 844.972                     | 381.220                     | 3,963.793                 | 3,811.337                 |
| xor                                    | 4,795.892     | 13,570.420        | 7,919.912         | 9,884.553         | 14,406.393            | 10,038.748            | 11,099.158            | 645.880                     | 360.885                     | 3,364.754                 | 3,346.572                 |
| original xor average                   | 5,130.525     | 14,031.721        | 8,482.820         | 10,242.655        | 16,454.061            | 11,033.062            | 12,711.172            | 829.797                     | 388.706                     | 3,780.939                 | 3,643.455                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| disjoint                               | 0.169         | 5,423.150         | 5,060.450         | 2,280.614         | 4,848.766             | 5,223.560             | 1,639.984             | 25.032                      | 0.143                       | 3,430.196                 | 3,744.891                 |
| disjoint                               | 0.107         | 5,288.349         | 5,477.972         | 2,387.449         | 5,007.689             | 5,122.024             | 1,633.462             | 13.834                      | 0.091                       | 3,491.174                 | 3,788.521                 |
| disjoint                               | 0.222         | 5,605.339         | 5,367.305         | 2,463.414         | 5,600.900             | 5,989.221             | 1,662.269             | 13.797                      | 0.090                       | 3,598.689                 | 3,877.460                 |
| disjoint                               | 0.117         | 5,507.348         | 5,350.934         | 2,475.010         | 5,101.607             | 5,261.371             | 1,699.821             | 12.881                      | 0.088                       | 3,640.761                 | 3,982.408                 |
| disjoint                               | 0.091         | 4,679.158         | 4,582.319         | 2,135.173         | 4,500.166             | 4,961.522             | 1,551.858             | 12.761                      | 0.115                       | 3,235.288                 | 3,730.767                 |
| original disjoint average              | 0.141         | 5,300.669         | 5,167.796         | 2,348.332         | 5,011.826             | 5,311.540             | 1,637.479             | 15.661                      | 0.105                       | 3,479.222                 | 3,824.809                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| equivalence                            | 0.102         | 3,765.865         | 4.947             | 0.024             | 4,258.086             | 5.076                 | 0.022                 | 1,375.723                   | 2,184.956                   | 0.087                     | 3.236                     |
| equivalence                            | 0.196         | 3,487.337         | 4.631             | 0.039             | 3,935.162             | 6.110                 | 0.023                 | 1,299.788                   | 1,932.168                   | 0.091                     | 3.084                     |
| equivalence                            | 0.134         | 3,793.092         | 4.815             | 0.046             | 4,030.678             | 5.335                 | 0.030                 | 1,276.185                   | 1,863.609                   | 0.146                     | 1.872                     |
| equivalence                            | 0.123         | 3,577.098         | 5.812             | 0.036             | 4,083.099             | 6.060                 | 0.022                 | 1,258.498                   | 1,999.499                   | 0.073                     | 1.776                     |
| equivalence                            | 0.112         | 3,274.627         | 5.011             | 0.026             | 3,692.570             | 5.123                 | 0.020                 | 1,173.084                   | 1,763.635                   | 0.093                     | 1.980                     |
| original equivalence average           | 0.133         | 3,579.604         | 5.043             | 0.034             | 3,999.919             | 5.541                 | 0.023                 | 1,276.656                   | 1,948.773                   | 0.098                     | 2.390                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| properSubset                           | 0.166         | 0.080             | 0.024             | 1,871.919         | 5.412                 | 0.028                 | 0.028                 | 0.106                       | 1.807                       | 0.057                     | 1.469                     |
| properSubset                           | 0.117         | 0.058             | 0.038             | 1,785.750         | 5.948                 | 0.027                 | 0.024                 | 0.055                       | 1.649                       | 0.056                     | 1.881                     |
| properSubset                           | 0.102         | 0.040             | 0.018             | 1,848.702         | 5.757                 | 0.027                 | 0.025                 | 0.054                       | 1.687                       | 0.068                     | 1.495                     |
| properSubset                           | 0.131         | 0.049             | 0.048             | 2,008.718         | 6.311                 | 0.026                 | 0.023                 | 0.050                       | 1.719                       | 0.066                     | 2.147                     |
| properSubset                           | 0.149         | 0.061             | 0.033             | 1,986.183         | 6.484                 | 0.026                 | 0.024                 | 0.054                       | 1.506                       | 0.068                     | 1.989                     |
| original properSubset average          | 0.133         | 0.058             | 0.032             | 1,900.254         | 5.982                 | 0.027                 | 0.025                 | 0.064                       | 1.674                       | 0.063                     | 1.796                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| properSuperset                         | 0.105         | 0.043             | 1,990.500         | 5.095             | 0.025                 | 2,471.807             | 4.959                 | 0.067                       | 0.822                       | 0.035                     | 0.678                     |
| properSuperset                         | 0.103         | 0.039             | 1,742.347         | 6.472             | 0.030                 | 2,528.196             | 5.643                 | 0.041                       | 0.777                       | 0.036                     | 0.960                     |
| properSuperset                         | 0.102         | 0.040             | 1,720.644         | 5.737             | 0.027                 | 2,531.367             | 4.848                 | 0.059                       | 0.853                       | 0.037                     | 0.640                     |
| properSuperset                         | 0.104         | 0.046             | 1,820.529         | 7.214             | 0.043                 | 2,573.628             | 5.389                 | 0.039                       | 0.777                       | 0.031                     | 0.659                     |
| properSuperset                         | 0.120         | 0.042             | 1,739.563         | 4.770             | 0.042                 | 2,642.126             | 6.754                 | 0.072                       | 0.887                       | 0.061                     | 0.671                     |
| original properSuperset average        | 0.107         | 0.042             | 1,802.717         | 5.858             | 0.033                 | 2,549.425             | 5.519                 | 0.056                       | 0.823                       | 0.040                     | 0.722                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| subset                                 | 0.124         | 3,492.658         | 5.927             | 1,832.577         | 3,564.048             | 0.021                 | 0.057                 | 1,275.574                   | 1,810.200                   | 0.041                     | 0.709                     |
| subset                                 | 0.107         | 3,534.076         | 7.095             | 1,773.470         | 3,727.766             | 0.021                 | 0.057                 | 1,328.451                   | 1,995.200                   | 0.057                     | 0.821                     |
| subset                                 | 0.105         | 3,546.864         | 4.649             | 1,847.932         | 3,715.620             | 0.027                 | 0.066                 | 1,312.542                   | 1,959.164                   | 0.039                     | 0.694                     |
| subset                                 | 0.103         | 3,593.232         | 4.719             | 1,990.088         | 4,037.688             | 0.057                 | 0.076                 | 1,441.152                   | 2,130.118                   | 0.062                     | 0.932                     |
| subset                                 | 0.129         | 3,734.322         | 6.547             | 2,086.307         | 3,547.387             | 0.021                 | 0.056                 | 1,205.137                   | 1,627.872                   | 0.037                     | 0.720                     |
| original subset average                | 0.114         | 3,580.230         | 5.787             | 1,906.075         | 3,718.502             | 0.029                 | 0.062                 | 1,312.571                   | 1,904.511                   | 0.047                     | 0.775                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| superset                               | 0.168         | 3,316.736         | 1,713.619         | 4.529             | 4,439.722             | 2,008.166             | 0.026                 | 554.054                     | 307.705                     | 0.140                     | 2.837                     |
| superset                               | 0.107         | 3,629.646         | 1,976.667         | 5.798             | 4,440.037             | 1,905.811             | 0.030                 | 533.766                     | 314.521                     | 0.139                     | 2.255                     |
| superset                               | 0.111         | 3,395.570         | 1,699.171         | 4.569             | 4,256.243             | 1,768.666             | 0.040                 | 626.424                     | 367.020                     | 0.095                     | 1.869                     |
| superset                               | 0.168         | 3,467.993         | 1,771.107         | 7.226             | 4,558.513             | 1,948.550             | 0.046                 | 531.274                     | 311.603                     | 0.099                     | 1.719                     |
| superset                               | 0.103         | 3,074.623         | 1,638.734         | 4.674             | 3,828.416             | 1,615.626             | 0.022                 | 435.511                     | 297.322                     | 0.112                     | 2.015                     |
| original superset average              | 0.131         | 3,376.914         | 1,759.860         | 5.359             | 4,304.586             | 1,849.364             | 0.033                 | 536.206                     | 319.634                     | 0.117                     | 2.139                     |
</details>

<details>
<summary><h3 style="display: inline">[rewrite] raw data:</h3></summary>

| Refactored Overall Timing: | time (ms)   |
|----------------------------|-------------|
| Refactored Run Timing 1    | 288,642.094 |
| Refactored Run Timing 2    | 275,319.999 |
| Refactored Run Timing 3    | 272,109.198 |
| Refactored Run Timing 4    | 276,547.708 |
| Refactored Run Timing 5    | 276,330.090 |
| Refactored Average         | 277,789.818 |


| Refactored Test Timing:                | function(of1) | function(of1 of1) | function(of1 of2) | function(of2 of1) | function(of1 of1 of1) | function(of1 of2 of3) | function(of3 of2 of1) | function(...someEquivalent) | function(...manyEquivalent) | function(...someDisjoint) | function(...manyDisjoint) |
|----------------------------------------|---------------|-------------------|-------------------|-------------------|-----------------------|-----------------------|-----------------------|-----------------------------|-----------------------------|---------------------------|---------------------------|
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| difference                             | 4,564.748     | 8,023.046         | 5,702.259         | 4,602.432         | 7,588.928             | 6,927.570             | 4,346.423             | 128.745                     | 120.904                     | 430.099                   | 301.463                   |
| difference                             | 4,668.882     | 8,076.489         | 5,855.001         | 4,796.708         | 7,736.303             | 6,801.491             | 4,442.305             | 127.901                     | 121.708                     | 494.231                   | 316.800                   |
| difference                             | 4,681.626     | 7,948.394         | 5,692.702         | 4,584.387         | 7,722.969             | 6,783.962             | 4,317.233             | 123.454                     | 122.704                     | 433.107                   | 277.706                   |
| difference                             | 4,720.510     | 8,290.482         | 5,650.647         | 4,623.631         | 7,596.155             | 6,477.422             | 4,217.465             | 126.614                     | 120.207                     | 500.940                   | 280.416                   |
| difference                             | 4,574.356     | 7,899.228         | 5,684.765         | 4,535.037         | 7,965.397             | 6,754.130             | 4,541.993             | 134.678                     | 122.510                     | 449.999                   | 285.719                   |
| refactored difference average          | 4,642.024     | 8,047.528         | 5,717.075         | 4,628.439         | 7,721.950             | 6,748.915             | 4,373.084             | 128.278                     | 121.607                     | 461.675                   | 292.421                   |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| intersection                           | 4,510.911     | 6,463.205         | 8,003.551         | 3,005.991         | 8,079.570             | 9,951.804             | 2,866.701             | 413.460                     | 253.273                     | 22.829                    | 0.280                     |
| intersection                           | 4,654.674     | 6,640.446         | 8,408.813         | 3,081.758         | 7,955.582             | 9,740.734             | 2,851.545             | 411.605                     | 255.041                     | 22.030                    | 0.281                     |
| intersection                           | 4,590.184     | 6,470.897         | 8,341.455         | 3,026.592         | 8,171.458             | 9,748.109             | 2,802.837             | 418.899                     | 257.601                     | 21.257                    | 0.325                     |
| intersection                           | 4,617.341     | 7,221.307         | 9,140.932         | 3,410.391         | 9,488.867             | 11,264.030            | 3,132.503             | 545.253                     | 259.109                     | 23.164                    | 0.260                     |
| intersection                           | 4,613.697     | 6,423.121         | 8,224.572         | 3,159.195         | 8,894.824             | 10,290.105            | 3,141.020             | 440.230                     | 266.356                     | 31.585                    | 0.279                     |
| refactored intersection average        | 4,597.361     | 6,643.795         | 8,423.865         | 3,136.785         | 8,518.060             | 10,198.956            | 2,958.921             | 445.889                     | 258.276                     | 24.173                    | 0.285                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| union                                  | 4,540.786     | 6,442.296         | 5,288.262         | 4,665.358         | 8,042.516             | 5,869.531             | 5,203.628             | 354.599                     | 198.650                     | 2,280.762                 | 2,294.081                 |
| union                                  | 4,379.386     | 6,439.609         | 5,428.922         | 5,628.076         | 8,990.968             | 6,220.146             | 5,397.109             | 353.852                     | 209.632                     | 2,319.683                 | 2,326.134                 |
| union                                  | 4,415.544     | 6,343.550         | 5,293.988         | 4,663.941         | 7,994.585             | 5,923.586             | 5,163.053             | 346.784                     | 202.019                     | 2,363.562                 | 2,718.809                 |
| union                                  | 4,378.483     | 6,580.500         | 5,296.989         | 4,756.681         | 8,176.736             | 6,009.502             | 5,240.826             | 357.192                     | 214.245                     | 2,364.711                 | 2,438.777                 |
| union                                  | 4,443.691     | 6,786.594         | 5,370.226         | 4,936.558         | 8,133.772             | 6,101.192             | 5,434.795             | 368.215                     | 206.981                     | 2,267.625                 | 2,520.559                 |
| refactored union average               | 4,431.578     | 6,518.510         | 5,335.677         | 4,930.123         | 8,267.715             | 6,024.791             | 5,287.882             | 356.128                     | 206.305                     | 2,319.269                 | 2,459.672                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| xor                                    | 4,691.465     | 12,607.457        | 7,429.844         | 8,922.345         | 14,017.462            | 9,675.381             | 10,872.007            | 574.581                     | 379.613                     | 3,314.359                 | 3,243.469                 |
| xor                                    | 4,661.065     | 12,710.441        | 7,468.356         | 8,739.933         | 14,492.680            | 9,714.942             | 10,982.374            | 585.862                     | 394.030                     | 3,216.547                 | 3,281.570                 |
| xor                                    | 4,425.131     | 13,010.814        | 7,324.160         | 9,121.583         | 14,401.427            | 9,895.614             | 11,046.562            | 629.289                     | 490.668                     | 3,349.852                 | 3,255.944                 |
| xor                                    | 4,679.335     | 13,000.930        | 7,758.847         | 9,479.477         | 14,398.505            | 9,496.149             | 10,722.644            | 601.723                     | 401.858                     | 3,221.916                 | 3,274.772                 |
| xor                                    | 4,384.000     | 13,378.016        | 7,598.049         | 9,366.973         | 14,224.476            | 9,992.448             | 11,132.366            | 604.096                     | 422.529                     | 3,289.256                 | 3,412.870                 |
| refactored xor average                 | 4,568.199     | 12,941.532        | 7,515.851         | 9,126.062         | 14,306.910            | 9,754.907             | 10,951.191            | 599.110                     | 417.740                     | 3,278.386                 | 3,293.725                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| disjoint                               | 0.093         | 4,656.372         | 4,510.699         | 2,076.384         | 4,449.636             | 4,605.348             | 1,500.091             | 11.593                      | 0.106                       | 3,167.915                 | 3,541.646                 |
| disjoint                               | 0.129         | 4,732.799         | 4,393.659         | 2,320.457         | 4,540.481             | 4,667.176             | 1,569.923             | 15.475                      | 0.095                       | 3,211.755                 | 3,304.454                 |
| disjoint                               | 0.126         | 4,757.052         | 4,631.875         | 2,390.959         | 4,520.993             | 4,514.778             | 1,461.208             | 11.863                      | 0.091                       | 3,120.539                 | 3,382.773                 |
| disjoint                               | 0.132         | 4,522.875         | 4,351.038         | 2,289.531         | 4,330.133             | 4,475.904             | 1,482.458             | 10.632                      | 0.134                       | 3,066.220                 | 3,118.501                 |
| disjoint                               | 0.110         | 4,767.378         | 4,501.325         | 2,299.071         | 4,325.568             | 4,394.375             | 1,562.986             | 11.943                      | 0.094                       | 3,246.284                 | 3,336.589                 |
| refactored disjoint average            | 0.118         | 4,687.295         | 4,477.719         | 2,275.280         | 4,433.362             | 4,531.516             | 1,515.333             | 12.301                      | 0.104                       | 3,162.543                 | 3,336.793                 |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| equivalence                            | 0.107         | 3,117.047         | 5.820             | 0.029             | 3,391.226             | 6.891                 | 0.034                 | 1,097.454                   | 1,581.260                   | 0.078                     | 2.079                     |
| equivalence                            | 0.178         | 3,430.409         | 9.389             | 0.040             | 3,355.050             | 5.877                 | 0.022                 | 1,150.195                   | 1,475.794                   | 0.094                     | 1.766                     |
| equivalence                            | 0.108         | 3,482.871         | 6.073             | 0.024             | 3,318.881             | 7.775                 | 0.052                 | 1,158.644                   | 1,503.521                   | 0.075                     | 1.723                     |
| equivalence                            | 0.103         | 3,366.130         | 6.234             | 0.024             | 3,251.042             | 6.280                 | 0.035                 | 1,108.791                   | 1,541.673                   | 0.073                     | 2.096                     |
| equivalence                            | 0.146         | 3,629.517         | 6.383             | 0.055             | 3,502.719             | 7.187                 | 0.022                 | 1,143.740                   | 1,560.473                   | 0.094                     | 1.797                     |
| refactored equivalence average         | 0.128         | 3,405.195         | 6.780             | 0.034             | 3,363.784             | 6.802                 | 0.033                 | 1,131.765                   | 1,532.544                   | 0.083                     | 1.892                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| properSubset                           | 0.102         | 0.040             | 0.018             | 1,621.546         | 6.952                 | 0.078                 | 0.046                 | 0.057                       | 1.667                       | 0.057                     | 1.724                     |
| properSubset                           | 0.143         | 0.060             | 0.042             | 1,614.597         | 6.588                 | 0.026                 | 0.037                 | 0.051                       | 1.763                       | 0.059                     | 1.564                     |
| properSubset                           | 0.197         | 0.070             | 0.027             | 1,614.651         | 6.241                 | 0.025                 | 0.027                 | 0.053                       | 1.636                       | 0.067                     | 1.455                     |
| properSubset                           | 0.099         | 0.040             | 0.019             | 1,569.154         | 6.381                 | 0.028                 | 0.027                 | 0.080                       | 1.534                       | 0.054                     | 1.429                     |
| properSubset                           | 0.102         | 0.042             | 0.018             | 1,587.207         | 6.062                 | 0.036                 | 0.069                 | 0.064                       | 2.171                       | 0.071                     | 1.803                     |
| refactored properSubset average        | 0.129         | 0.050             | 0.025             | 1,601.431         | 6.445                 | 0.039                 | 0.041                 | 0.061                       | 1.754                       | 0.062                     | 1.595                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| properSuperset                         | 0.165         | 0.044             | 1,022.832         | 4.931             | 0.024                 | 1,600.086             | 5.532                 | 0.045                       | 0.659                       | 0.030                     | 0.677                     |
| properSuperset                         | 0.104         | 0.052             | 1,085.676         | 5.667             | 0.044                 | 1,752.940             | 8.301                 | 0.059                       | 0.952                       | 0.034                     | 0.670                     |
| properSuperset                         | 0.107         | 0.041             | 1,034.587         | 5.470             | 0.028                 | 1,587.619             | 5.727                 | 0.033                       | 0.757                       | 0.033                     | 0.665                     |
| properSuperset                         | 0.100         | 0.039             | 1,010.420         | 5.329             | 0.028                 | 1,630.839             | 5.755                 | 0.037                       | 0.694                       | 0.032                     | 0.680                     |
| properSuperset                         | 0.102         | 0.044             | 1,018.538         | 5.548             | 0.025                 | 1,667.037             | 5.623                 | 0.033                       | 0.647                       | 0.030                     | 0.637                     |
| refactored properSuperset average      | 0.116         | 0.044             | 1,034.411         | 5.389             | 0.030                 | 1,647.704             | 6.188                 | 0.041                       | 0.742                       | 0.032                     | 0.666                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| subset                                 | 0.184         | 3,093.809         | 5.645             | 1,572.337         | 3,150.220             | 0.025                 | 0.070                 | 1,099.662                   | 1,614.952                   | 0.035                     | 0.745                     |
| subset                                 | 0.108         | 3,138.970         | 6.372             | 1,622.438         | 3,317.195             | 0.021                 | 0.060                 | 1,149.189                   | 1,576.316                   | 0.042                     | 1.394                     |
| subset                                 | 0.105         | 3,185.200         | 5.913             | 1,631.470         | 3,317.596             | 0.024                 | 0.084                 | 1,129.225                   | 1,500.902                   | 0.040                     | 0.759                     |
| subset                                 | 0.107         | 3,055.141         | 5.907             | 1,581.414         | 3,191.644             | 0.021                 | 0.060                 | 1,125.636                   | 1,503.085                   | 0.035                     | 1.116                     |
| subset                                 | 0.103         | 3,069.687         | 6.575             | 1,593.279         | 3,219.999             | 0.044                 | 0.105                 | 1,125.901                   | 1,663.621                   | 0.036                     | 0.712                     |
| refactored subset average              | 0.121         | 3,108.561         | 6.082             | 1,600.188         | 3,239.331             | 0.027                 | 0.076                 | 1,125.923                   | 1,571.775                   | 0.038                     | 0.945                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| superset                               | 0.100         | 2,009.890         | 1,035.019         | 5.385             | 3,540.830             | 1,499.819             | 0.021                 | 381.329                     | 213.606                     | 0.079                     | 1.789                     |
| superset                               | 0.100         | 1,955.577         | 1,055.754         | 5.184             | 3,552.632             | 1,520.938             | 0.021                 | 347.379                     | 212.825                     | 0.125                     | 1.686                     |
| superset                               | 0.109         | 2,039.461         | 1,003.173         | 5.015             | 3,551.098             | 1,464.204             | 0.022                 | 351.129                     | 223.811                     | 0.096                     | 1.845                     |
| superset                               | 0.150         | 2,018.943         | 1,003.234         | 5.411             | 3,486.807             | 1,450.989             | 0.022                 | 356.281                     | 253.062                     | 0.079                     | 1.729                     |
| superset                               | 0.097         | 2,004.886         | 1,131.414         | 5.675             | 3,465.645             | 1,540.291             | 0.023                 | 445.109                     | 230.705                     | 0.114                     | 1.750                     |
| refactored superset average            | 0.111         | 2,005.751         | 1,045.719         | 5.334             | 3,519.402             | 1,495.248             | 0.022                 | 376.245                     | 226.802                     | 0.099                     | 1.760                     |
</details>

<details>
<summary><h3 style="display: inline">[performance improvement] raw data:</h3></summary>

| Average Overall Timing:         | time (ms)   |
|---------------------------------|-------------|
| Original Average                | 314,121.793 |
| Refactored Average              | 277,789.818 |
| Overall Performance Improvement | 11.57%      |

| Average Test Timing:                   | function(of1) | function(of1 of1) | function(of1 of2) | function(of2 of1) | function(of1 of1 of1) | function(of1 of2 of3) | function(of3 of2 of1) | function(...someEquivalent) | function(...manyEquivalent) | function(...someDisjoint) | function(...manyDisjoint) |
|----------------------------------------|---------------|-------------------|-------------------|-------------------|-----------------------|-----------------------|-----------------------|-----------------------------|-----------------------------|---------------------------|---------------------------|
| original difference average            | 5,283.998     | 9,340.487         | 6,502.256         | 5,290.898         | 8,822.696             | 7,517.870             | 4,844.235             | 164.125                     | 146.473                     | 563.267                   | 330.243                   |
| refactored difference average          | 4,642.024     | 8,047.528         | 5,717.075         | 4,628.439         | 7,721.950             | 6,748.915             | 4,373.084             | 128.278                     | 121.607                     | 461.675                   | 292.421                   |
| difference performance improvement     | 12.15%        | 13.84%            | 12.08%            | 12.52%            | 12.48%                | 10.23%                | 9.73%                 | 21.84%                      | 16.98%                      | 18.04%                    | 11.45%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original intersection average          | 4,839.347     | 8,540.523         | 9,578.826         | 3,326.797         | 9,056.382             | 11,406.444            | 3,333.685             | 494.584                     | 297.539                     | 33.419                    | 0.414                     |
| refactored intersection average        | 4,597.361     | 6,643.795         | 8,423.865         | 3,136.785         | 8,518.060             | 10,198.956            | 2,958.921             | 445.889                     | 258.276                     | 24.173                    | 0.285                     |
| intersection performance improvement   | 5.00%         | 22.21%            | 12.06%            | 5.71%             | 5.94%                 | 10.59%                | 11.24%                | 9.85%                       | 13.20%                      | 27.67%                    | 31.23%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original union average                 | 5,006.154     | 7,469.266         | 5,987.302         | 5,447.200         | 9,272.908             | 6,672.998             | 5,834.525             | 517.077                     | 260.883                     | 2,564.899                 | 2,750.470                 |
| refactored union average               | 4,431.578     | 6,518.510         | 5,335.677         | 4,930.123         | 8,267.715             | 6,024.791             | 5,287.882             | 356.128                     | 206.305                     | 2,319.269                 | 2,459.672                 |
| union performance improvement          | 11.48%        | 12.73%            | 10.88%            | 9.49%             | 10.84%                | 9.71%                 | 9.37%                 | 31.13%                      | 20.92%                      | 9.58%                     | 10.57%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original xor average                   | 5,130.525     | 14,031.721        | 8,482.820         | 10,242.655        | 16,454.061            | 11,033.062            | 12,711.172            | 829.797                     | 388.706                     | 3,780.939                 | 3,643.455                 |
| refactored xor average                 | 4,568.199     | 12,941.532        | 7,515.851         | 9,126.062         | 14,306.910            | 9,754.907             | 10,951.191            | 599.110                     | 417.740                     | 3,278.386                 | 3,293.725                 |
| xor performance improvement            | 10.96%        | 7.77%             | 11.40%            | 10.90%            | 13.05%                | 11.58%                | 13.85%                | 27.80%                      | -7.47%                      | 13.29%                    | 9.60%                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original disjoint average              | 0.141         | 5,300.669         | 5,167.796         | 2,348.332         | 5,011.826             | 5,311.540             | 1,637.479             | 15.661                      | 0.105                       | 3,479.222                 | 3,824.809                 |
| refactored disjoint average            | 0.118         | 4,687.295         | 4,477.719         | 2,275.280         | 4,433.362             | 4,531.516             | 1,515.333             | 12.301                      | 0.104                       | 3,162.543                 | 3,336.793                 |
| disjoint performance improvement       | 16.43%        | 11.57%            | 13.35%            | 3.11%             | 11.54%                | 14.69%                | 7.46%                 | 21.45%                      | 1.33%                       | 9.10%                     | 12.76%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original equivalence average           | 0.133         | 3,579.604         | 5.043             | 0.034             | 3,999.919             | 5.541                 | 0.023                 | 1,276.656                   | 1,948.773                   | 0.098                     | 2.390                     |
| refactored equivalence average         | 0.128         | 3,405.195         | 6.780             | 0.034             | 3,363.784             | 6.802                 | 0.033                 | 1,131.765                   | 1,532.544                   | 0.083                     | 1.892                     |
| equivalence performance improvement    | 4.05%         | 4.87%             | -34.44%           | 0.58%             | 15.90%                | -22.76%               | -41.03%               | 11.35%                      | 21.36%                      | 15.31%                    | 20.82%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original properSubset average          | 0.133         | 0.058             | 0.032             | 1,900.254         | 5.982                 | 0.027                 | 0.025                 | 0.064                       | 1.674                       | 0.063                     | 1.796                     |
| refactored properSubset average        | 0.129         | 0.050             | 0.025             | 1,601.431         | 6.445                 | 0.039                 | 0.041                 | 0.061                       | 1.754                       | 0.062                     | 1.595                     |
| properSubset performance improvement   | 3.01%         | 13.19%            | 22.36%            | 15.73%            | -7.73%                | -45.52%               | -65.32%               | 4.39%                       | -4.80%                      | 1.59%                     | 11.20%                    |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original properSuperset average        | 0.107         | 0.042             | 1,802.717         | 5.858             | 0.033                 | 2,549.425             | 5.519                 | 0.056                       | 0.823                       | 0.040                     | 0.722                     |
| refactored properSuperset average      | 0.116         | 0.044             | 1,034.411         | 5.389             | 0.030                 | 1,647.704             | 6.188                 | 0.041                       | 0.742                       | 0.032                     | 0.666                     |
| properSuperset performance improvement | -8.61%        | -4.76%            | 42.62%            | 8.00%             | 10.18%                | 35.37%                | -12.13%               | 26.26%                      | 9.86%                       | 20.00%                    | 7.71%                     |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original subset average                | 0.114         | 3,580.230         | 5.787             | 1,906.075         | 3,718.502             | 0.029                 | 0.062                 | 1,312.571                   | 1,904.511                   | 0.047                     | 0.775                     |
| refactored subset average              | 0.121         | 3,108.561         | 6.082             | 1,600.188         | 3,239.331             | 0.027                 | 0.076                 | 1,125.923                   | 1,571.775                   | 0.038                     | 0.945                     |
| subset performance improvement         | -6.51%        | 13.17%            | -5.09%            | 16.05%            | 12.89%                | 8.16%                 | -21.79%               | 14.22%                      | 17.47%                      | 19.49%                    | -21.90%                   |
|                                        |               |                   |                   |                   |                       |                       |                       |                             |                             |                           |                           |
| original superset average              | 0.131         | 3,376.914         | 1,759.860         | 5.359             | 4,304.586             | 1,849.364             | 0.033                 | 536.206                     | 319.634                     | 0.117                     | 2.139                     |
| refactored superset average            | 0.111         | 2,005.751         | 1,045.719         | 5.334             | 3,519.402             | 1,495.248             | 0.022                 | 376.245                     | 226.802                     | 0.099                     | 1.760                     |
| superset performance improvement       | 15.53%        | 40.60%            | 40.58%            | 0.47%             | 18.24%                | 19.15%                | 32.93%                | 29.83%                      | 29.04%                      | 15.38%                    | 17.72%                    |
</details>
