### PR TITLE
remove named booleans on cardinality comparisons

### DIFF
--- a/src/comparisons/equivalence.function.ts
+++ b/src/comparisons/equivalence.function.ts
@@ -18,10 +18,7 @@ export function equivalence<T, S extends ReadonlySet<T>>(...sets: S[]): boolean 
 
 	const cardinalities = sets.map(set => set.size);
 	const primaryCardinality = cardinalities.shift()!;
-	const allSetsHaveEqualCardinalities = cardinalities
-		.every(cardinality => cardinality === primaryCardinality);
-
-	if (!allSetsHaveEqualCardinalities) {
+	if (!cardinalities.every(cardinality => cardinality === primaryCardinality)) {
 		return false;
 	}
 

--- a/src/comparisons/proper-subset.function.ts
+++ b/src/comparisons/proper-subset.function.ts
@@ -18,10 +18,7 @@ export function properSubset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean
 
 	const cardinalities = sets.map(set => set.size);
 	const primaryCardinality = cardinalities.shift()!;
-	const allSetsHaveGreaterCardinalities = cardinalities
-		.every(cardinality => cardinality > primaryCardinality);
-
-	if (!allSetsHaveGreaterCardinalities) {
+	if (!cardinalities.every(cardinality => cardinality > primaryCardinality)) {
 		return false;
 	}
 

--- a/src/comparisons/proper-superset.function.ts
+++ b/src/comparisons/proper-superset.function.ts
@@ -18,10 +18,7 @@ export function properSuperset<T, S extends ReadonlySet<T>>(...sets: S[]): boole
 
 	const cardinalities = sets.map(set => set.size);
 	const primaryCardinality = cardinalities.shift()!;
-	const allSetsHaveLesserCardinalities = cardinalities
-		.every(cardinality => cardinality < primaryCardinality);
-
-	if (!allSetsHaveLesserCardinalities) {
+	if (!cardinalities.every(cardinality => cardinality < primaryCardinality)) {
 		return false;
 	}
 

--- a/src/comparisons/subset.function.ts
+++ b/src/comparisons/subset.function.ts
@@ -17,10 +17,7 @@ export function subset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 
 	const cardinalities = sets.map(set => set.size);
 	const primaryCardinality = cardinalities.shift()!;
-	const allSetsHaveGreaterCardinalities = cardinalities
-		.every(cardinality => cardinality >= primaryCardinality);
-
-	if (!allSetsHaveGreaterCardinalities) {
+	if (!cardinalities.every(cardinality => cardinality >= primaryCardinality)) {
 		return false;
 	}
 

--- a/src/comparisons/superset.function.ts
+++ b/src/comparisons/superset.function.ts
@@ -19,10 +19,7 @@ export function superset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 
 	const cardinalities = sets.map(set => set.size);
 	const primaryCardinality = cardinalities.shift()!;
-	const allSetsHaveLesserCardinalities = cardinalities
-		.every(cardinality => cardinality <= primaryCardinality);
-
-	if (!allSetsHaveLesserCardinalities) {
+	if (!cardinalities.every(cardinality => cardinality <= primaryCardinality)) {
 		return false;
 	}
 


### PR DESCRIPTION
While I will admit that the booleans names were remarkably clear, they were in no way concise. And I found that the resulting code was overall less legible at a glance. So I have removed the named booleans in favor of inlining their `cardinalities.every()` in the respective if statements.