### PR TITLE
remove source maps from distributed package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
 
 		"baseUrl": "./",
 		"outDir": "./dist",
-		"sourceMap": true,
 		"declaration": true,
 		"moduleResolution": "node",
 		"skipLibCheck": true,


### PR DESCRIPTION
Ultimately, when it comes to the decision over which files to publish in the distributed package, there are two options to consider:

1. Publish both `sources` & `source maps`.
2. Publish neither `sources` nor `source maps`.

This is because, fundamentally, in order for end users to use `source maps` for debugging purposes, they would need the associated `sources` available in the package.

Given that we currently do not currently publish `sources`: option 1 would mean adding `sources` to the package, whereas option 2 would be to remove the `source maps`. And after some `npm publish --dry-run` testing, the differential end result is that adding `sources` would increase the package size by ~100% over removing `source maps`.

Further reading on the discussion: https://github.com/googleapis/google-cloud-node/issues/2867