### PR TITLE
added `pairwiseDisjoint` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ const isDisjointAB = disjoint(setA, setB);
 const isDisjointABC = disjoint(setA, setB, setC);
 ```
 
+### pairwise disjoint: `A ∩ B ∩ C = ∅`
+A Family of Sets are pairwise disjoint if
+none of the Sets share any elements in common.
+
+![pairwise disjoint visual][pairwise-disjoint-visual-url]
+```typescript
+import { pairwiseDisjoint } from 'set-utilities';
+
+const isPairwiseDisjointAB = pairwiseDisjoint(setA, setB);
+const isPairwiseDisjointABC = pairwiseDisjoint(setA, setB, setC);
+```
+
 ### subset: `A ⊆ B`
 A set is a subset of another if all of its elements
 are elements of the other set.
@@ -179,6 +191,7 @@ const sortedByComparator = sort(setA, comparatorFunction);
 
 [equivalence-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/equivalence.svg
 [disjoint-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/disjoint.svg
+[pairwise-disjoint-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/pairwise-disjoint.svg
 [subset-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/subset.svg
 [proper-subset-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/proper-subset.svg
 [superset-visual-url]: https://github.com/kubikowski/set-utilities/wiki/assets/superset.svg

--- a/src/comparisons/disjoint.function.ts
+++ b/src/comparisons/disjoint.function.ts
@@ -2,7 +2,9 @@ export function disjoint<T>(...sets: Set<T>[]): boolean;
 export function disjoint<T>(...sets: ReadonlySet<T>[]): boolean;
 
 /**
- * Sets are disjoint if they share no elements in common.
+ * A Set is disjoint from another (or thereafter)
+ * if it shares no elements in common with the other set (or thereafter).
+ *
  * Set disjoint is also commonly referred to as mutually exclusive, or independent.
  *
  * Set disjoint does not have a common notation.
@@ -15,13 +17,11 @@ export function disjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
 		return true;
 	}
 
-	const allElements = new Set<T>(sets.shift());
+	const primarySet = sets.shift()!;
 	for (const set of sets) {
 		for (const element of set) {
-			if (allElements.has(element)) {
+			if (primarySet.has(element)) {
 				return false;
-			} else {
-				allElements.add(element);
 			}
 		}
 	}

--- a/src/comparisons/pairwise-disjoint.function.ts
+++ b/src/comparisons/pairwise-disjoint.function.ts
@@ -1,0 +1,30 @@
+export function pairwiseDisjoint<T>(...sets: Set<T>[]): boolean;
+export function pairwiseDisjoint<T>(...sets: ReadonlySet<T>[]): boolean;
+
+/**
+ * A Family of Sets are pairwise disjoint
+ * if none of the Sets share any elements in common.
+ *
+ * Set pairwise disjoint does not have a common notation.
+ * However, the disjoint union of sets is notated as A ⊔ B.
+ *
+ * @description pairwise disjoint F ⇔ (∀A,B ∈ F) ⇒ (A ∩ B = ∅)
+ */
+export function pairwiseDisjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+	if (sets.length < 2) {
+		return true;
+	}
+
+	const allElements = new Set<T>(sets.shift());
+	for (const set of sets) {
+		for (const element of set) {
+			if (allElements.has(element)) {
+				return false;
+			} else {
+				allElements.add(element);
+			}
+		}
+	}
+
+	return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { disjoint } from './comparisons/disjoint.function';
 export { equivalence } from './comparisons/equivalence.function';
+export { pairwiseDisjoint } from './comparisons/pairwise-disjoint.function';
 export { properSubset } from './comparisons/proper-subset.function';
 export { properSuperset } from './comparisons/proper-superset.function';
 export { subset } from './comparisons/subset.function';

--- a/test/comparisons/disjoint.function.test.ts
+++ b/test/comparisons/disjoint.function.test.ts
@@ -48,4 +48,12 @@ describe('disjoint', () => {
 	it('two sets with no shared values are disjoint', () => {
 		expect(disjoint(setA, setD)).toBe(true);
 	});
+
+	it('many sets with no shared values are disjoint', () => {
+		expect(disjoint(setA, setD, setE, setF)).toBe(true);
+	});
+
+	it('a set & many of another set with no shared values are disjoint', () => {
+		expect(disjoint(setA, setD, setD, setD)).toBe(true);
+	});
 });

--- a/test/comparisons/pairwise-disjoint.function.test.ts
+++ b/test/comparisons/pairwise-disjoint.function.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from '@jest/globals';
+import { pairwiseDisjoint } from '../../src';
+import { empty, setA, setB, setC, setD, setE, setF, universal } from '../constants/testing-constants';
+
+describe('pairwise disjoint', () => {
+	it('no sets are pairwise disjoint', () => {
+		expect(pairwiseDisjoint()).toBe(true);
+	});
+
+	it('single set is pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA)).toBe(true);
+	});
+
+	it('same set is not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setA)).toBe(false);
+	});
+
+	it('many of the same set are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setA, setA)).toBe(false);
+	});
+
+	it('two sets with some shared values are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setB)).toBe(false);
+	});
+
+	it('three sets with some shared values are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setB, setC)).toBe(false);
+	});
+
+	it('many sets with some shared values are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('any non-empty set and the empty set are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, empty)).toBe(true);
+	});
+
+	it('any non-empty set and the universal set are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, universal)).toBe(false);
+	});
+
+	it('the empty set is pairwise disjoint with itself', () => {
+		expect(pairwiseDisjoint(empty, empty)).toBe(true);
+	});
+
+	/* custom pairwise disjoint tests */
+
+	it('two sets with no shared values are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setD)).toBe(true);
+	});
+
+	it('many sets with no shared values are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setD, setE, setF)).toBe(true);
+	});
+
+	it('a set & many of another set with no shared values are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setD, setD, setD)).toBe(false);
+	});
+});

--- a/test/constants/testing-constants.ts
+++ b/test/constants/testing-constants.ts
@@ -23,9 +23,9 @@ export const setB = new Set<number>([ 0, 1, 3, 5 ]);
 export const setC = new Set<number>([ 0, 2, 3, 6 ]);
 /* contains: 7 */
 export const setD = new Set<number>([ 7 ]);
-/* contains: 7 */
+/* contains: 8 */
 export const setE = new Set<number>([ 8 ]);
-/* contains: 7 */
+/* contains: 9 */
 export const setF = new Set<number>([ 9 ]);
 
 /* the universal set: U, contains: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 */

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -27,7 +27,7 @@ describe('Scale Tests', () => {
 	const someDisjoint = Multiples.someDisjoint;
 	const manyDisjoint = Multiples.manyDisjoint;
 
-	const padding = 34;
+	const padding = 36;
 	Timer.logAll();
 
 	describe('Operations', () => {

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -4,6 +4,7 @@ import {
 	disjoint,
 	equivalence,
 	intersection,
+	pairwiseDisjoint,
 	properSubset,
 	properSuperset,
 	sort,
@@ -318,6 +319,54 @@ describe('Scale Tests', () => {
 				expect(result).toBe(false);
 			});
 			afterAll(() => Timer.log('equivalence'));
+		});
+
+		describe('pairwise disjoint', () => {
+			it('pairwiseDisjoint(of1):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1));
+				expect(result).toBe(true);
+			});
+			it('pairwiseDisjoint(of1, of1):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(of1, of2):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1, multiplesOf2));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(of2, of1):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(of1, of1, of1):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1, multiplesOf1, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(of1, of2, of3):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1, multiplesOf2, multiplesOf3));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(of3, of2, of1):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf3, multiplesOf2, multiplesOf1));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(...someEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...someEquivalent));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(...manyEquivalent):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...manyEquivalent));
+				expect(result).toBe(false);
+			});
+			it('pairwiseDisjoint(...someDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...someDisjoint));
+				expect(result).toBe(true);
+			});
+			it('pairwiseDisjoint(...manyDisjoint):'.padEnd(padding), () => {
+				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...manyDisjoint));
+				expect(result).toBe(true);
+			});
+			afterAll(() => Timer.log('pairwiseDisjoint'));
 		});
 
 		describe('proper subset', () => {


### PR DESCRIPTION
### Split `disjoint` into 2 separate implementations:

1. `disjoint`: only compares the primary set to its peers.
2. `pairwiseDisjoint`: compares all sets to each other.

### `disjoint` performance:
In the process of this implementation spliltting, `disjoint` function received a tremendous performance increase. The scale tests showed that its performance improved by will into the 90% range, and all of the worst case scenario tests put it well past 99% time reduction.

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[original] raw data:</h4></summary>

|              | disjoint(of1) | disjoint(of1, of1) | disjoint(of1, of2) | disjoint(of2, of1) | disjoint(of1, of1, of1) | disjoint(of1, of2, of3) | disjoint(of3, of2, of1) |
|:-------------|:--------------|:-------------------|:-------------------|:-------------------|:------------------------|:------------------------|:------------------------|
| test 1:      | 0.073ms       | 4773.485+ms        | 4583.291ms         | 2398.631ms         | 4642.292ms              | 4547.358ms              | 1517.781ms              |
| test 2:      | 0.071ms       | 4630.294+ms        | 4398.869ms         | 2317.750ms         | 4475.264ms              | 4414.893ms              | 1422.378ms              |
| test 3:      | 0.074ms       | 4252.868+ms        | 4400.087ms         | 2080.325ms         | 4431.705ms              | 4645.330ms              | 1502.654ms              |
| test 4:      | 0.072ms       | 4299.106+ms        | 4182.782ms         | 2166.214ms         | 4255.342ms              | 4185.491ms              | 1363.329ms              |
| test 5:      | 0.073ms       | 4394.865+ms        | 4563.516ms         | 2111.330ms         | 4375.145ms              | 4661.734ms              | 1475.484ms              |
|              |
| **average:** | **0.073ms**   | **4470.124ms**     | **4425.709ms**     | **2214.850ms**     | **4435.950ms**          | **4490.961ms**          | **1456.325ms**          |

|              | disjoint(...someEq) | disjoint(...manyEq) | disjoint(...someDj) | disjoint(...manyDj) |
|:-------------|:--------------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 12.024ms            | 0.139+ms            | 3333.470ms          | 3556.341+ms         |
| test 2:      | 13.770ms            | 0.128+ms            | 3085.717ms          | 3267.323+ms         |
| test 3:      | 16.655ms            | 0.209+ms            | 3160.434ms          | 3387.256+ms         |
| test 4:      | 11.441ms            | 0.134+ms            | 3193.293ms          | 3242.309+ms         |
| test 5:      | 12.341ms            | 0.135+ms            | 3116.726ms          | 3295.282+ms         |
|              |
| **average:** | **13.246ms**        | **0.149ms**         | **3177.928ms**      | **3349.702ms**      |
</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[refactor] raw data:</h4></summary>

|              | disjoint(of1) | disjoint(of1, of1) | disjoint(of1, of2) | disjoint(of2, of1) | disjoint(of1, of1, of1) | disjoint(of1, of2, of3) | disjoint(of3, of2, of1) |
|:-------------|:--------------|:-------------------|:-------------------|:-------------------|:------------------------|:------------------------|:------------------------|
| test 1:      | 0.063+ms      | 0.037ms            | 0.038ms            | 0.033ms            | 0.034ms                 | 0.026ms                 | 0.023+ms                |
| test 2:      | 0.088+ms      | 0.029ms            | 0.020ms            | 0.019ms            | 0.056ms                 | 0.021ms                 | 0.021+ms                |
| test 3:      | 0.068+ms      | 0.037ms            | 0.049ms            | 0.033ms            | 0.044ms                 | 0.033ms                 | 0.029+ms                |
| test 4:      | 0.101+ms      | 0.033ms            | 0.042ms            | 0.022ms            | 0.022ms                 | 0.022ms                 | 0.033+ms                |
| test 5:      | 0.069+ms      | 0.029ms            | 0.024ms            | 0.020ms            | 0.023ms                 | 0.023ms                 | 0.035+ms                |
|              |
| **average:** | **0.078ms**   | **0.033ms**        | **0.035ms**        | **0.025ms**        | **0.036ms**             | **0.025ms**             | **0.028ms**             |

|              | disjoint(...someEq) | disjoint(...manyEq) | disjoint(...someDj) | disjoint(...manyDj) |
|:-------------|:--------------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 0.042ms             | 0.067ms             | 419.229ms           | 287.990ms           |
| test 2:      | 0.020ms             | 0.064ms             | 498.446ms           | 294.927ms           |
| test 3:      | 0.037ms             | 0.087ms             | 455.726ms           | 291.338ms           |
| test 4:      | 0.037ms             | 0.092ms             | 464.725ms           | 319.511ms           |
| test 5:      | 0.028ms             | 0.114ms             | 455.723ms           | 305.098ms           |
|              |
| **average:** | **0.033ms**         | **0.085ms**         | **458.770ms**       | **299.773ms**       |

</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[performance improvement] raw data:</h4></summary>

|                  | disjoint(of1) | disjoint(of1, of1) | disjoint(of1, of2) | disjoint(of2, of1) | disjoint(of1, of1, of1) | disjoint(of1, of2, of3) | disjoint(of3, of2, of1) |
|:-----------------|:--------------|:-------------------|:-------------------|:-------------------|:------------------------|:------------------------|:------------------------|
| original:        | 0.073ms       | 4470.124ms         | 4425.709ms         | 2214.850ms         | 4435.950ms              | 4490.961ms              | 1456.325ms              |
| rewrite:         | 0.078ms       | 0.033ms            | 0.035ms            | 0.025ms            | 0.036ms                 | 0.025ms                 | 0.028ms                 |
|                  |
| **improvement:** | **-6.849%**   | **+99.999%**       | **+99.999%**       | **+99.998%**       | **+99.999%**            | **+99.999%**            | **+99.998%**            |

|                  | disjoint(...someEq) | disjoint(...manyEq) | disjoint(...someDj) | disjoint(...manyDj) |
|:-----------------|:--------------------|:--------------------|:--------------------|:--------------------|
| original:        | 13.246ms            | 0.149ms             | 3177.928ms          | 3349.702ms          |
| rewrite:         | 0.033ms             | 0.085ms             | 458.770ms           | 299.773ms           |
|                  |
| **improvement:** | **+99.751%**        | **+42.953%**        | **+85.564%**        | **+91.051%**        |
</details>


