### PR TITLE
eslint --fix dist

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,13 +3,15 @@
 	"overrides": [
 		{
 			"files": [
+				"*.js",
 				"*.ts"
 			],
 			"parserOptions": {
 				"project": [
 					"tsconfig.json"
 				],
-				"createDefaultProgram": true
+				"createDefaultProgram": true,
+				"sourceType": "module"
 			},
 			"extends": [
 				"eslint:recommended",
@@ -214,6 +216,7 @@
 					"error",
 					"as-needed"
 				],
+				"brace-style": "error",
 				"comma-dangle": "off",
 				"func-style": [
 					"error",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	"scripts": {
 		"build": "tsc",
 		"lint": "eslint . --ext .ts",
+		"postbuild": "eslint --fix dist/**",
 		"prebuild": "rimraf dist",
 		"prepack": "npm run build",
 		"pretest:coverage": "rimraf coverage",


### PR DESCRIPTION
In perusing the output dist files, I noticed some oddities in how TSC outputs the compiled JS. Especially given that ti does not match the formatting applied to the TS.

So, I have added an `eslint --fix dist` step into the build. And I have specified additional rules in the `eslint` to specifically target the output JS files.