### PR TITLE
removed unused dev-depencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,7 @@
 			"files": [
 				"*.ts"
 			],
+			"parser": "@typescript-eslint/parser",
 			"parserOptions": {
 				"project": [
 					"tsconfig.json"
@@ -70,6 +71,7 @@
 				"plugin:@typescript-eslint/recommended"
 			],
 			"plugins": [
+				"@typescript-eslint",
 				"import"
 			],
 			"rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
 				"@babel/core": "^7.19.1",
 				"@babel/preset-env": "^7.19.1",
 				"@babel/preset-typescript": "^7.18.6",
-				"@types/jest": "^29.0.3",
-				"@types/node": "^18.7.18",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
 				"babel-jest": "^29.0.3",
@@ -2458,16 +2456,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"node_modules/@types/jest": {
-			"version": "29.0.3",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.3.tgz",
-			"integrity": "sha512-F6ukyCTwbfsEX5F2YmVYmM5TcTHy1q9P5rWlRbrk56KyMh3v9xRGUO3aa8+SkvMi0SHXtASJv1283enXimC0Og==",
-			"dev": true,
-			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
 			}
 		},
 		"node_modules/@types/json-schema": {
@@ -8757,16 +8745,6 @@
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"@types/jest": {
-			"version": "29.0.3",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.3.tgz",
-			"integrity": "sha512-F6ukyCTwbfsEX5F2YmVYmM5TcTHy1q9P5rWlRbrk56KyMh3v9xRGUO3aa8+SkvMi0SHXtASJv1283enXimC0Og==",
-			"dev": true,
-			"requires": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
 			}
 		},
 		"@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
 		"@babel/core": "^7.19.1",
 		"@babel/preset-env": "^7.19.1",
 		"@babel/preset-typescript": "^7.18.6",
-		"@types/jest": "^29.0.3",
-		"@types/node": "^18.7.18",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",
 		"babel-jest": "^29.0.3",


### PR DESCRIPTION
Also, added explicit use of `@typescript-eslint/parser` in eslint.