### PR TITLE
added horizontal scale tests

### DIFF
--- a/test/constants/multiples.model.ts
+++ b/test/constants/multiples.model.ts
@@ -3,8 +3,17 @@ import { Timer } from './timer.model';
 /**
  * Scale Testing Sets:
  *
- * Each set listed below contains all the multiples
- * of a given number, from `0` up to `15 Million`.
+ * The vertical scale: single sets
+ * each contain all the multiples of a given number,
+ * from `0` up to `15 Million`.
+ *
+ * The vertical scale: multiple sets
+ * each create an Array of Sets, which contain a
+ * total of `10 Million` elements between all the Sets.
+ *
+ * The horizontal scale
+ * each create an Array of Sets, which contain a
+ * total of `100` elements between all the sets.
  *
  * Note: Sets of `size > 16,777,216` will fail to instantiate,
  * or will fail to add values afterwards, with the following error message:
@@ -13,49 +22,58 @@ import { Timer } from './timer.model';
  * ```
  */
 export abstract class Multiples {
-	private static _of1?: ReadonlySet<number>;
-	private static _of2?: ReadonlySet<number>;
-	private static _of3?: ReadonlySet<number>;
-	private static _someEquivalent?: ReadonlyArray<ReadonlySet<number>>;
-	private static _manyEquivalent?: ReadonlyArray<ReadonlySet<number>>;
-	private static _someDisjoint?: ReadonlyArray<ReadonlySet<number>>;
-	private static _manyDisjoint?: ReadonlyArray<ReadonlySet<number>>;
 
+	// region vertical scale: single sets
 	public static get of1(): ReadonlySet<number> {
-		if (typeof this._of1 === 'undefined') this._of1 = Multiples.of(1, 15_000_000);
-		return this._of1;
+		return Multiples.of(1, 15_000_000);
 	}
 
 	public static get of2(): ReadonlySet<number> {
-		if (typeof this._of2 === 'undefined') this._of2 = Multiples.of(2, 7_500_000);
-		return this._of2;
+		return Multiples.of(2, 7_500_000);
 	}
 
 	public static get of3(): ReadonlySet<number> {
-		if (typeof this._of3 === 'undefined') this._of3 = Multiples.of(3, 5_000_000);
-		return this._of3;
+		return Multiples.of(3, 5_000_000);
 	}
+	// endregion vertical scale: single sets
 
+	// region vertical scale: multiple sets
 	public static get someEquivalent(): ReadonlyArray<ReadonlySet<number>> {
-		if (typeof this._someEquivalent === 'undefined') this._someEquivalent = Multiples.manyOf(100, 100_000);
-		return this._someEquivalent;
+		return Multiples.manyOf(100, 100_000);
 	}
 
 	public static get manyEquivalent(): ReadonlyArray<ReadonlySet<number>> {
-		if (typeof this._manyEquivalent === 'undefined') this._manyEquivalent = Multiples.manyOf(10_000, 1_000);
-		return this._manyEquivalent;
+		return Multiples.manyOf(10_000, 1_000);
 	}
 
 	public static get someDisjoint(): ReadonlyArray<ReadonlySet<number>> {
-		if (typeof this._someDisjoint === 'undefined') this._someDisjoint = Multiples.manyOf(100, 100_000, true);
-		return this._someDisjoint;
+		return Multiples.manyOf(100, 100_000, true);
 	}
 
 	public static get manyDisjoint(): ReadonlyArray<ReadonlySet<number>> {
-		if (typeof this._manyDisjoint === 'undefined') this._manyDisjoint = Multiples.manyOf(10_000, 1_000, true);
-		return this._manyDisjoint;
+		return Multiples.manyOf(10_000, 1_000, true);
+	}
+	// endregion  vertical scale: multiple sets
+
+	// region horizontal scale
+	public static get coupleEquivalent(): ReadonlyArray<ReadonlySet<number>> {
+		return Multiples.manyOf(2, 50);
 	}
 
+	public static get fewEquivalent(): ReadonlyArray<ReadonlySet<number>> {
+		return Multiples.manyOf(5, 20);
+	}
+
+	public static get coupleDisjoint(): ReadonlyArray<ReadonlySet<number>> {
+		return Multiples.manyOf(2, 50, true);
+	}
+
+	public static get fewDisjoint(): ReadonlyArray<ReadonlySet<number>> {
+		return Multiples.manyOf(5, 20, true);
+	}
+	// endregion horizontal scale
+
+	// region constructors
 	private static of(factor: number, size: number, offset = 0): ReadonlySet<number> {
 		return Timer.time('copying multiples', () =>
 			new Set<number>(Array.from(
@@ -74,4 +92,5 @@ export abstract class Multiples {
 				)),
 			));
 	}
+	// endregion constructors
 }

--- a/test/constants/sort-testing-constants.ts
+++ b/test/constants/sort-testing-constants.ts
@@ -1,7 +1,21 @@
 import { expect } from '@jest/globals';
 
 /* unordered universal set, contains: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 */
-export const unordered = new Set([ 4, 9, 6, 1, 8, 2, 5, 7, 0, 3 ]);
+export const unordered = new Set<number>([ 4, 9, 6, 1, 8, 2, 5, 7, 0, 3 ]);
+
+/* unordered set of 100 elements, contains: 0 - 99 */
+export const manyUnordered = new Set<number>([
+	98, 49, 85, 53, 83, 57, 86, 94, 82, 47,
+	21, 45, 29, 15, 66, 64, 76, 84, 9, 73,
+	26, 80, 32, 91, 65, 38, 14, 24, 13, 78,
+	10, 37, 92, 95, 18, 69, 6, 25, 3, 87,
+	51, 48, 71, 81, 77, 27, 41, 79, 97, 33,
+	60, 89, 55, 36, 63, 50, 93, 30, 4, 62,
+	8, 31, 17, 88, 40, 39, 46, 52, 56, 42,
+	72, 28, 44, 59, 43, 99, 68, 35, 2, 90,
+	96, 19, 54, 70, 7, 61, 75, 23, 22, 5,
+	11, 34, 16, 67, 0, 20, 12, 74, 1, 58,
+]);
 
 /* (default) less than comparator function */
 export function defaultComparator<T>(a: T, b: T): number {

--- a/test/constants/timer.model.ts
+++ b/test/constants/timer.model.ts
@@ -12,6 +12,14 @@ export abstract class Timer {
 		return result;
 	}
 
+	public static manyTimes<T>(methodName: string, method: () => T, times: number): void {
+		const timeStart = performance.now();
+		for (let i = 0; i < times; ++i) method();
+		const timeEnd = performance.now();
+
+		Timer.add(methodName, timeEnd - timeStart);
+	}
+
 	private static add(methodName: string, timing: number): void {
 		if (!Timer.timings.has(methodName)) {
 			Timer.timings.set(methodName, []);

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -14,7 +14,7 @@ import {
 	xor,
 } from '../src';
 import { Multiples } from './constants/multiples.model';
-import { defaultComparator, reverseComparator } from './constants/sort-testing-constants';
+import { defaultComparator, manyUnordered, reverseComparator } from './constants/sort-testing-constants';
 import { Timer } from './constants/timer.model';
 
 describe('Scale Tests', () => {
@@ -825,6 +825,21 @@ describe('Scale Tests', () => {
 			it('sort(of3, reverse):'.padEnd(padding), () => {
 				const result = Timer.time('sort', () => sort(multiplesOf3, reverseComparator));
 				expect(result.size).toBe(5_000_000);
+			});
+			it('100k ⋅ sort(100):'.padEnd(padding), () => {
+				const sortMock = jest.fn(sort);
+				Timer.manyTimes('sort', () => sortMock(manyUnordered), times);
+				expect(sortMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ sort(100, default):'.padEnd(padding), () => {
+				const sortMock = jest.fn(sort);
+				Timer.manyTimes('sort', () => sortMock(manyUnordered, defaultComparator), times);
+				expect(sortMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ sort(100, reverse):'.padEnd(padding), () => {
+				const sortMock = jest.fn(sort);
+				Timer.manyTimes('sort', () => sortMock(manyUnordered, reverseComparator), times);
+				expect(sortMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('sort'));
 		});

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from '@jest/globals';
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
 import {
 	difference,
 	disjoint,
@@ -27,7 +27,13 @@ describe('Scale Tests', () => {
 	const someDisjoint = Multiples.someDisjoint;
 	const manyDisjoint = Multiples.manyDisjoint;
 
-	const padding = 36;
+	const coupleEquivalent = Multiples.coupleEquivalent;
+	const fewEquivalent = Multiples.fewEquivalent;
+	const coupleDisjoint = Multiples.coupleDisjoint;
+	const fewDisjoint = Multiples.fewDisjoint;
+	const times = 100_000;
+
+	const padding = 38;
 	Timer.logAll();
 
 	describe('Operations', () => {
@@ -75,6 +81,26 @@ describe('Scale Tests', () => {
 			it('difference(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('difference', () => difference(...manyDisjoint));
 				expect(result.size).toBe(1_000);
+			});
+			it('100k ⋅ difference(2 Equivalent):'.padEnd(padding), () => {
+				const differenceMock = jest.fn(difference);
+				Timer.manyTimes('difference', () => differenceMock(...coupleEquivalent), times);
+				expect(differenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ difference(5 Equivalent):'.padEnd(padding), () => {
+				const differenceMock = jest.fn(difference);
+				Timer.manyTimes('difference', () => differenceMock(...fewEquivalent), times);
+				expect(differenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ difference(2 Disjoint):'.padEnd(padding), () => {
+				const differenceMock = jest.fn(difference);
+				Timer.manyTimes('difference', () => differenceMock(...coupleDisjoint), times);
+				expect(differenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ difference(5 Disjoint):'.padEnd(padding), () => {
+				const differenceMock = jest.fn(difference);
+				Timer.manyTimes('difference', () => differenceMock(...fewDisjoint), times);
+				expect(differenceMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('difference'));
 		});
@@ -124,6 +150,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('intersection', () => intersection(...manyDisjoint));
 				expect(result.size).toBe(0);
 			});
+			it('100k ⋅ intersection(2 Equivalent):'.padEnd(padding), () => {
+				const intersectionMock = jest.fn(intersection);
+				Timer.manyTimes('intersection', () => intersectionMock(...coupleEquivalent), times);
+				expect(intersectionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ intersection(5 Equivalent):'.padEnd(padding), () => {
+				const intersectionMock = jest.fn(intersection);
+				Timer.manyTimes('intersection', () => intersectionMock(...fewEquivalent), times);
+				expect(intersectionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ intersection(2 Disjoint):'.padEnd(padding), () => {
+				const intersectionMock = jest.fn(intersection);
+				Timer.manyTimes('intersection', () => intersectionMock(...coupleDisjoint), times);
+				expect(intersectionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ intersection(5 Disjoint):'.padEnd(padding), () => {
+				const intersectionMock = jest.fn(intersection);
+				Timer.manyTimes('intersection', () => intersectionMock(...fewDisjoint), times);
+				expect(intersectionMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('intersection'));
 		});
 
@@ -172,6 +218,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('union', () => union(...manyDisjoint));
 				expect(result.size).toBe(10_000_000);
 			});
+			it('100k ⋅ union(2 Equivalent):'.padEnd(padding), () => {
+				const unionMock = jest.fn(union);
+				Timer.manyTimes('union', () => unionMock(...coupleEquivalent), times);
+				expect(unionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ union(5 Equivalent):'.padEnd(padding), () => {
+				const unionMock = jest.fn(union);
+				Timer.manyTimes('union', () => unionMock(...fewEquivalent), times);
+				expect(unionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ union(2 Disjoint):'.padEnd(padding), () => {
+				const unionMock = jest.fn(union);
+				Timer.manyTimes('union', () => unionMock(...coupleDisjoint), times);
+				expect(unionMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ union(5 Disjoint):'.padEnd(padding), () => {
+				const unionMock = jest.fn(union);
+				Timer.manyTimes('union', () => unionMock(...fewDisjoint), times);
+				expect(unionMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('union'));
 		});
 
@@ -219,6 +285,26 @@ describe('Scale Tests', () => {
 			it('xor(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('xor', () => xor(...manyDisjoint));
 				expect(result.size).toBe(10_000_000);
+			});
+			it('100k ⋅ xor(2 Equivalent):'.padEnd(padding), () => {
+				const xorMock = jest.fn(xor);
+				Timer.manyTimes('xor', () => xorMock(...coupleEquivalent), times);
+				expect(xorMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ xor(5 Equivalent):'.padEnd(padding), () => {
+				const xorMock = jest.fn(xor);
+				Timer.manyTimes('xor', () => xorMock(...fewEquivalent), times);
+				expect(xorMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ xor(2 Disjoint):'.padEnd(padding), () => {
+				const xorMock = jest.fn(xor);
+				Timer.manyTimes('xor', () => xorMock(...coupleDisjoint), times);
+				expect(xorMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ xor(5 Disjoint):'.padEnd(padding), () => {
+				const xorMock = jest.fn(xor);
+				Timer.manyTimes('xor', () => xorMock(...fewDisjoint), times);
+				expect(xorMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('xor'));
 		});
@@ -270,6 +356,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('disjoint', () => disjoint(...manyDisjoint));
 				expect(result).toBe(true);
 			});
+			it('100k ⋅ disjoint(2 Equivalent):'.padEnd(padding), () => {
+				const disjointMock = jest.fn(disjoint);
+				Timer.manyTimes('disjoint', () => disjointMock(...coupleEquivalent), times);
+				expect(disjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ disjoint(5 Equivalent):'.padEnd(padding), () => {
+				const disjointMock = jest.fn(disjoint);
+				Timer.manyTimes('disjoint', () => disjointMock(...fewEquivalent), times);
+				expect(disjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ disjoint(2 Disjoint):'.padEnd(padding), () => {
+				const disjointMock = jest.fn(disjoint);
+				Timer.manyTimes('disjoint', () => disjointMock(...coupleDisjoint), times);
+				expect(disjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ disjoint(5 Disjoint):'.padEnd(padding), () => {
+				const disjointMock = jest.fn(disjoint);
+				Timer.manyTimes('disjoint', () => disjointMock(...fewDisjoint), times);
+				expect(disjointMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('disjoint'));
 		});
 
@@ -317,6 +423,26 @@ describe('Scale Tests', () => {
 			it('equivalence(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('equivalence', () => equivalence(...manyDisjoint));
 				expect(result).toBe(false);
+			});
+			it('100k ⋅ equivalence(2 Equivalent):'.padEnd(padding), () => {
+				const equivalenceMock = jest.fn(equivalence);
+				Timer.manyTimes('equivalence', () => equivalenceMock(...coupleEquivalent), times);
+				expect(equivalenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ equivalence(5 Equivalent):'.padEnd(padding), () => {
+				const equivalenceMock = jest.fn(equivalence);
+				Timer.manyTimes('equivalence', () => equivalenceMock(...fewEquivalent), times);
+				expect(equivalenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ equivalence(2 Disjoint):'.padEnd(padding), () => {
+				const equivalenceMock = jest.fn(equivalence);
+				Timer.manyTimes('equivalence', () => equivalenceMock(...coupleDisjoint), times);
+				expect(equivalenceMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ equivalence(5 Disjoint):'.padEnd(padding), () => {
+				const equivalenceMock = jest.fn(equivalence);
+				Timer.manyTimes('equivalence', () => equivalenceMock(...fewDisjoint), times);
+				expect(equivalenceMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('equivalence'));
 		});
@@ -366,6 +492,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...manyDisjoint));
 				expect(result).toBe(true);
 			});
+			it('100k ⋅ pairwiseDisjoint(2 Equivalent):'.padEnd(padding), () => {
+				const pairwiseDisjointMock = jest.fn(pairwiseDisjoint);
+				Timer.manyTimes('pairwiseDisjoint', () => pairwiseDisjointMock(...coupleEquivalent), times);
+				expect(pairwiseDisjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ pairwiseDisjoint(5 Equivalent):'.padEnd(padding), () => {
+				const pairwiseDisjointMock = jest.fn(pairwiseDisjoint);
+				Timer.manyTimes('pairwiseDisjoint', () => pairwiseDisjointMock(...fewEquivalent), times);
+				expect(pairwiseDisjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ pairwiseDisjoint(2 Disjoint):'.padEnd(padding), () => {
+				const pairwiseDisjointMock = jest.fn(pairwiseDisjoint);
+				Timer.manyTimes('pairwiseDisjoint', () => pairwiseDisjointMock(...coupleDisjoint), times);
+				expect(pairwiseDisjointMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ pairwiseDisjoint(5 Disjoint):'.padEnd(padding), () => {
+				const pairwiseDisjointMock = jest.fn(pairwiseDisjoint);
+				Timer.manyTimes('pairwiseDisjoint', () => pairwiseDisjointMock(...fewDisjoint), times);
+				expect(pairwiseDisjointMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('pairwiseDisjoint'));
 		});
 
@@ -413,6 +559,26 @@ describe('Scale Tests', () => {
 			it('properSubset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('properSubset', () => properSubset(...manyDisjoint));
 				expect(result).toBe(false);
+			});
+			it('100k ⋅ properSubset(2 Equivalent):'.padEnd(padding), () => {
+				const properSubsetMock = jest.fn(properSubset);
+				Timer.manyTimes('properSubset', () => properSubsetMock(...coupleEquivalent), times);
+				expect(properSubsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSubset(5 Equivalent):'.padEnd(padding), () => {
+				const properSubsetMock = jest.fn(properSubset);
+				Timer.manyTimes('properSubset', () => properSubsetMock(...fewEquivalent), times);
+				expect(properSubsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSubset(2 Disjoint):'.padEnd(padding), () => {
+				const properSubsetMock = jest.fn(properSubset);
+				Timer.manyTimes('properSubset', () => properSubsetMock(...coupleDisjoint), times);
+				expect(properSubsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSubset(5 Disjoint):'.padEnd(padding), () => {
+				const properSubsetMock = jest.fn(properSubset);
+				Timer.manyTimes('properSubset', () => properSubsetMock(...fewDisjoint), times);
+				expect(properSubsetMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('properSubset'));
 		});
@@ -462,6 +628,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('properSuperset', () => properSuperset(...manyDisjoint));
 				expect(result).toBe(false);
 			});
+			it('100k ⋅ properSuperset(2 Equivalent):'.padEnd(padding), () => {
+				const properSupersetMock = jest.fn(properSuperset);
+				Timer.manyTimes('properSuperset', () => properSupersetMock(...coupleEquivalent), times);
+				expect(properSupersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSuperset(5 Equivalent):'.padEnd(padding), () => {
+				const properSupersetMock = jest.fn(properSuperset);
+				Timer.manyTimes('properSuperset', () => properSupersetMock(...fewEquivalent), times);
+				expect(properSupersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSuperset(2 Disjoint):'.padEnd(padding), () => {
+				const properSupersetMock = jest.fn(properSuperset);
+				Timer.manyTimes('properSuperset', () => properSupersetMock(...coupleDisjoint), times);
+				expect(properSupersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ properSuperset(5 Disjoint):'.padEnd(padding), () => {
+				const properSupersetMock = jest.fn(properSuperset);
+				Timer.manyTimes('properSuperset', () => properSupersetMock(...fewDisjoint), times);
+				expect(properSupersetMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('properSuperset'));
 		});
 
@@ -510,6 +696,26 @@ describe('Scale Tests', () => {
 				const result = Timer.time('subset', () => subset(...manyDisjoint));
 				expect(result).toBe(false);
 			});
+			it('100k ⋅ subset(2 Equivalent):'.padEnd(padding), () => {
+				const subsetMock = jest.fn(subset);
+				Timer.manyTimes('subset', () => subsetMock(...coupleEquivalent), times);
+				expect(subsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ subset(5 Equivalent):'.padEnd(padding), () => {
+				const subsetMock = jest.fn(subset);
+				Timer.manyTimes('subset', () => subsetMock(...fewEquivalent), times);
+				expect(subsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ subset(2 Disjoint):'.padEnd(padding), () => {
+				const subsetMock = jest.fn(subset);
+				Timer.manyTimes('subset', () => subsetMock(...coupleDisjoint), times);
+				expect(subsetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ subset(5 Disjoint):'.padEnd(padding), () => {
+				const subsetMock = jest.fn(subset);
+				Timer.manyTimes('subset', () => subsetMock(...fewDisjoint), times);
+				expect(subsetMock).toHaveBeenCalledTimes(times);
+			});
 			afterAll(() => Timer.log('subset'));
 		});
 
@@ -557,6 +763,26 @@ describe('Scale Tests', () => {
 			it('superset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('superset', () => superset(...manyDisjoint));
 				expect(result).toBe(false);
+			});
+			it('100k ⋅ superset(2 Equivalent):'.padEnd(padding), () => {
+				const supersetMock = jest.fn(superset);
+				Timer.manyTimes('superset', () => supersetMock(...coupleEquivalent), times);
+				expect(supersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ superset(5 Equivalent):'.padEnd(padding), () => {
+				const supersetMock = jest.fn(superset);
+				Timer.manyTimes('superset', () => supersetMock(...fewEquivalent), times);
+				expect(supersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ superset(2 Disjoint):'.padEnd(padding), () => {
+				const supersetMock = jest.fn(superset);
+				Timer.manyTimes('superset', () => supersetMock(...coupleDisjoint), times);
+				expect(supersetMock).toHaveBeenCalledTimes(times);
+			});
+			it('100k ⋅ superset(5 Disjoint):'.padEnd(padding), () => {
+				const supersetMock = jest.fn(superset);
+				Timer.manyTimes('superset', () => supersetMock(...fewDisjoint), times);
+				expect(supersetMock).toHaveBeenCalledTimes(times);
 			});
 			afterAll(() => Timer.log('superset'));
 		});

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from '@jest/globals';
+import { afterAll, describe, expect, it } from '@jest/globals';
 import {
 	difference,
 	disjoint,
@@ -60,19 +60,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('difference', () => difference(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result.size).toBe(0);
 			});
-			it('difference(...someEquivalent):'.padEnd(padding), () => {
+			it('difference(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('difference', () => difference(...someEquivalent));
 				expect(result.size).toBe(0);
 			});
-			it('difference(...manyEquivalent):'.padEnd(padding), () => {
+			it('difference(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('difference', () => difference(...manyEquivalent));
 				expect(result.size).toBe(0);
 			});
-			it('difference(...someDisjoint):'.padEnd(padding), () => {
+			it('difference(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('difference', () => difference(...someDisjoint));
 				expect(result.size).toBe(100_000);
 			});
-			it('difference(...manyDisjoint):'.padEnd(padding), () => {
+			it('difference(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('difference', () => difference(...manyDisjoint));
 				expect(result.size).toBe(1_000);
 			});
@@ -108,19 +108,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('intersection', () => intersection(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result.size).toBe(2_500_000);
 			});
-			it('intersection(...someEquivalent):'.padEnd(padding), () => {
+			it('intersection(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('intersection', () => intersection(...someEquivalent));
 				expect(result.size).toBe(100_000);
 			});
-			it('intersection(...manyEquivalent):'.padEnd(padding), () => {
+			it('intersection(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('intersection', () => intersection(...manyEquivalent));
 				expect(result.size).toBe(1_000);
 			});
-			it('intersection(...someDisjoint):'.padEnd(padding), () => {
+			it('intersection(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('intersection', () => intersection(...someDisjoint));
 				expect(result.size).toBe(0);
 			});
-			it('intersection(...manyDisjoint):'.padEnd(padding), () => {
+			it('intersection(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('intersection', () => intersection(...manyDisjoint));
 				expect(result.size).toBe(0);
 			});
@@ -156,19 +156,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('union', () => union(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result.size).toBe(15_000_000);
 			});
-			it('union(...someEquivalent):'.padEnd(padding), () => {
+			it('union(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('union', () => union(...someEquivalent));
 				expect(result.size).toBe(100_000);
 			});
-			it('union(...manyEquivalent):'.padEnd(padding), () => {
+			it('union(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('union', () => union(...manyEquivalent));
 				expect(result.size).toBe(1_000);
 			});
-			it('union(...someDisjoint):'.padEnd(padding), () => {
+			it('union(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('union', () => union(...someDisjoint));
 				expect(result.size).toBe(10_000_000);
 			});
-			it('union(...manyDisjoint):'.padEnd(padding), () => {
+			it('union(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('union', () => union(...manyDisjoint));
 				expect(result.size).toBe(10_000_000);
 			});
@@ -204,19 +204,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('xor', () => xor(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result.size).toBe(5_000_000);
 			});
-			it('xor(...someEquivalent):'.padEnd(padding), () => {
+			it('xor(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('xor', () => xor(...someEquivalent));
 				expect(result.size).toBe(0);
 			});
-			it('xor(...manyEquivalent):'.padEnd(padding), () => {
+			it('xor(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('xor', () => xor(...manyEquivalent));
 				expect(result.size).toBe(0);
 			});
-			it('xor(...someDisjoint):'.padEnd(padding), () => {
+			it('xor(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('xor', () => xor(...someDisjoint));
 				expect(result.size).toBe(10_000_000);
 			});
-			it('xor(...manyDisjoint):'.padEnd(padding), () => {
+			it('xor(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('xor', () => xor(...manyDisjoint));
 				expect(result.size).toBe(10_000_000);
 			});
@@ -254,19 +254,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('disjoint', () => disjoint(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('disjoint(...someEquivalent):'.padEnd(padding), () => {
+			it('disjoint(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('disjoint', () => disjoint(...someEquivalent));
 				expect(result).toBe(false);
 			});
-			it('disjoint(...manyEquivalent):'.padEnd(padding), () => {
+			it('disjoint(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('disjoint', () => disjoint(...manyEquivalent));
 				expect(result).toBe(false);
 			});
-			it('disjoint(...someDisjoint):'.padEnd(padding), () => {
+			it('disjoint(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('disjoint', () => disjoint(...someDisjoint));
 				expect(result).toBe(true);
 			});
-			it('disjoint(...manyDisjoint):'.padEnd(padding), () => {
+			it('disjoint(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('disjoint', () => disjoint(...manyDisjoint));
 				expect(result).toBe(true);
 			});
@@ -302,19 +302,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('equivalence', () => equivalence(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('equivalence(...someEquivalent):'.padEnd(padding), () => {
+			it('equivalence(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('equivalence', () => equivalence(...someEquivalent));
 				expect(result).toBe(true);
 			});
-			it('equivalence(...manyEquivalent):'.padEnd(padding), () => {
+			it('equivalence(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('equivalence', () => equivalence(...manyEquivalent));
 				expect(result).toBe(true);
 			});
-			it('equivalence(...someDisjoint):'.padEnd(padding), () => {
+			it('equivalence(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('equivalence', () => equivalence(...someDisjoint));
 				expect(result).toBe(false);
 			});
-			it('equivalence(...manyDisjoint):'.padEnd(padding), () => {
+			it('equivalence(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('equivalence', () => equivalence(...manyDisjoint));
 				expect(result).toBe(false);
 			});
@@ -350,19 +350,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('pairwiseDisjoint(...someEquivalent):'.padEnd(padding), () => {
+			it('pairwiseDisjoint(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...someEquivalent));
 				expect(result).toBe(false);
 			});
-			it('pairwiseDisjoint(...manyEquivalent):'.padEnd(padding), () => {
+			it('pairwiseDisjoint(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...manyEquivalent));
 				expect(result).toBe(false);
 			});
-			it('pairwiseDisjoint(...someDisjoint):'.padEnd(padding), () => {
+			it('pairwiseDisjoint(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...someDisjoint));
 				expect(result).toBe(true);
 			});
-			it('pairwiseDisjoint(...manyDisjoint):'.padEnd(padding), () => {
+			it('pairwiseDisjoint(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...manyDisjoint));
 				expect(result).toBe(true);
 			});
@@ -398,19 +398,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('properSubset', () => properSubset(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('properSubset(...someEquivalent):'.padEnd(padding), () => {
+			it('properSubset(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('properSubset', () => properSubset(...someEquivalent));
 				expect(result).toBe(false);
 			});
-			it('properSubset(...manyEquivalent):'.padEnd(padding), () => {
+			it('properSubset(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('properSubset', () => properSubset(...manyEquivalent));
 				expect(result).toBe(false);
 			});
-			it('properSubset(...someDisjoint):'.padEnd(padding), () => {
+			it('properSubset(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('properSubset', () => properSubset(...someDisjoint));
 				expect(result).toBe(false);
 			});
-			it('properSubset(...manyDisjoint):'.padEnd(padding), () => {
+			it('properSubset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('properSubset', () => properSubset(...manyDisjoint));
 				expect(result).toBe(false);
 			});
@@ -446,19 +446,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('properSuperset', () => properSuperset(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('properSuperset(...someEquivalent):'.padEnd(padding), () => {
+			it('properSuperset(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('properSuperset', () => properSuperset(...someEquivalent));
 				expect(result).toBe(false);
 			});
-			it('properSuperset(...manyEquivalent):'.padEnd(padding), () => {
+			it('properSuperset(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('properSuperset', () => properSuperset(...manyEquivalent));
 				expect(result).toBe(false);
 			});
-			it('properSuperset(...someDisjoint):'.padEnd(padding), () => {
+			it('properSuperset(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('properSuperset', () => properSuperset(...someDisjoint));
 				expect(result).toBe(false);
 			});
-			it('properSuperset(...manyDisjoint):'.padEnd(padding), () => {
+			it('properSuperset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('properSuperset', () => properSuperset(...manyDisjoint));
 				expect(result).toBe(false);
 			});
@@ -494,19 +494,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('subset', () => subset(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('subset(...someEquivalent):'.padEnd(padding), () => {
+			it('subset(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('subset', () => subset(...someEquivalent));
 				expect(result).toBe(true);
 			});
-			it('subset(...manyEquivalent):'.padEnd(padding), () => {
+			it('subset(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('subset', () => subset(...manyEquivalent));
 				expect(result).toBe(true);
 			});
-			it('subset(...someDisjoint):'.padEnd(padding), () => {
+			it('subset(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('subset', () => subset(...someDisjoint));
 				expect(result).toBe(false);
 			});
-			it('subset(...manyDisjoint):'.padEnd(padding), () => {
+			it('subset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('subset', () => subset(...manyDisjoint));
 				expect(result).toBe(false);
 			});
@@ -542,19 +542,19 @@ describe('Scale Tests', () => {
 				const result = Timer.time('superset', () => superset(multiplesOf3, multiplesOf2, multiplesOf1));
 				expect(result).toBe(false);
 			});
-			it('superset(...someEquivalent):'.padEnd(padding), () => {
+			it('superset(100 Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('superset', () => superset(...someEquivalent));
 				expect(result).toBe(true);
 			});
-			it('superset(...manyEquivalent):'.padEnd(padding), () => {
+			it('superset(10k Equivalent):'.padEnd(padding), () => {
 				const result = Timer.time('superset', () => superset(...manyEquivalent));
 				expect(result).toBe(true);
 			});
-			it('superset(...someDisjoint):'.padEnd(padding), () => {
+			it('superset(100 Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('superset', () => superset(...someDisjoint));
 				expect(result).toBe(false);
 			});
-			it('superset(...manyDisjoint):'.padEnd(padding), () => {
+			it('superset(10k Disjoint):'.padEnd(padding), () => {
 				const result = Timer.time('superset', () => superset(...manyDisjoint));
 				expect(result).toBe(false);
 			});


### PR DESCRIPTION
### added horizontal scale tests:

Each of the functions now have 4 additional scale tests. Each new test calls the function `100,000` times, with input Sets that contain a total of `100` entries.
1. `100k ⋅ function(2 Equivalent)`: 2 equivalent Sets of 50 entries each.
2. `100k ⋅ function(5 Equivalent)`: 5 equivalent Sets of 20 entries each.
3. `100k ⋅ function(2 Disjoint)`: 2 disjoint Sets of 50 entries each.
4. `100k ⋅ function(5 Disjoint)`: 5 disjoint Sets of 20 entries each.