### PR TITLE
added all builtins unit tests

### DIFF
--- a/test/comparisons/disjoint.function.test.ts
+++ b/test/comparisons/disjoint.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { disjoint } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('disjoint', () => {
-	describe('disjoint ⋅ number', () => disjointTests(new NumberTestSets()));
-	describe('disjoint ⋅ string', () => disjointTests(new StringTestSets()));
-	describe('disjoint ⋅ symbol', () => disjointTests(new SymbolTestSets()));
+	testSuite('disjoint', disjointTests);
 });
 
 function disjointTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/equivalence.function.test.ts
+++ b/test/comparisons/equivalence.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { equivalence } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('equivalence', () => {
-	describe('equivalence ⋅ number', () => equivalenceTests(new NumberTestSets()));
-	describe('equivalence ⋅ string', () => equivalenceTests(new StringTestSets()));
-	describe('equivalence ⋅ symbol', () => equivalenceTests(new SymbolTestSets()));
+	testSuite('equivalence', equivalenceTests);
 });
 
 function equivalenceTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/pairwise-disjoint.function.test.ts
+++ b/test/comparisons/pairwise-disjoint.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { pairwiseDisjoint } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('pairwise disjoint', () => {
-	describe('pairwise disjoint ⋅ number', () => pairwiseDisjointTests(new NumberTestSets()));
-	describe('pairwise disjoint ⋅ string', () => pairwiseDisjointTests(new StringTestSets()));
-	describe('pairwise disjoint ⋅ symbol', () => pairwiseDisjointTests(new SymbolTestSets()));
+	testSuite('pairwise disjoint', pairwiseDisjointTests);
 });
 
 function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/proper-subset.function.test.ts
+++ b/test/comparisons/proper-subset.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { properSubset } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('proper subset', () => {
-	describe('proper subset ⋅ number', () => properSubsetTests(new NumberTestSets()));
-	describe('proper subset ⋅ string', () => properSubsetTests(new StringTestSets()));
-	describe('proper subset ⋅ symbol', () => properSubsetTests(new SymbolTestSets()));
+	testSuite('proper subset', properSubsetTests);
 });
 
 function properSubsetTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/proper-superset.function.test.ts
+++ b/test/comparisons/proper-superset.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { properSuperset } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('proper superset', () => {
-	describe('proper superset ⋅ number', () => properSupersetTests(new NumberTestSets()));
-	describe('proper superset ⋅ string', () => properSupersetTests(new StringTestSets()));
-	describe('proper superset ⋅ symbol', () => properSupersetTests(new SymbolTestSets()));
+	testSuite('proper superset', properSupersetTests);
 });
 
 function properSupersetTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/subset.function.test.ts
+++ b/test/comparisons/subset.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { subset } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('subset', () => {
-	describe('subset ⋅ number', () => subsetTests(new NumberTestSets()));
-	describe('subset ⋅ string', () => subsetTests(new StringTestSets()));
-	describe('subset ⋅ symbol', () => subsetTests(new SymbolTestSets()));
+	testSuite('subset', subsetTests);
 });
 
 function subsetTests<T>(testSets: TestSets<T>): void {

--- a/test/comparisons/superset.function.test.ts
+++ b/test/comparisons/superset.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { superset } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('superset', () => {
-	describe('superset ⋅ number', () => supersetTests(new NumberTestSets()));
-	describe('superset ⋅ string', () => supersetTests(new StringTestSets()));
-	describe('superset ⋅ symbol', () => supersetTests(new SymbolTestSets()));
+	testSuite('superset', supersetTests);
 });
 
 function supersetTests<T>(testSets: TestSets<T>): void {

--- a/test/operations/difference.function.test.ts
+++ b/test/operations/difference.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { difference, equivalence } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('difference', () => {
-	describe('difference ⋅ number', () => differenceTests(new NumberTestSets()));
-	describe('difference ⋅ string', () => differenceTests(new StringTestSets()));
-	describe('difference ⋅ symbol', () => differenceTests(new SymbolTestSets()));
+	testSuite('difference', differenceTests);
 });
 
 function differenceTests<T>(testSets: TestSets<T>): void {

--- a/test/operations/intersection.function.test.ts
+++ b/test/operations/intersection.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { equivalence, intersection } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('intersection', () => {
-	describe('intersection ⋅ number', () => intersectionTests(new NumberTestSets()));
-	describe('intersection ⋅ string', () => intersectionTests(new StringTestSets()));
-	describe('intersection ⋅ symbol', () => intersectionTests(new SymbolTestSets()));
+	testSuite('intersection', intersectionTests);
 });
 
 function intersectionTests<T>(testSets: TestSets<T>): void {

--- a/test/operations/union.function.test.ts
+++ b/test/operations/union.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { equivalence, union } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('union', () => {
-	describe('union ⋅ number', () => unionTests(new NumberTestSets()));
-	describe('union ⋅ string', () => unionTests(new StringTestSets()));
-	describe('union ⋅ symbol', () => unionTests(new SymbolTestSets()));
+	testSuite('union', unionTests);
 });
 
 function unionTests<T>(testSets: TestSets<T>): void {

--- a/test/operations/xor.function.test.ts
+++ b/test/operations/xor.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { equivalence, xor } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('xor', () => {
-	describe('xor ⋅ number', () => xorTests(new NumberTestSets()));
-	describe('xor ⋅ string', () => xorTests(new StringTestSets()));
-	describe('xor ⋅ symbol', () => xorTests(new SymbolTestSets()));
+	testSuite('xor', xorTests);
 });
 
 function xorTests<T>(testSets: TestSets<T>): void {

--- a/test/ordering/sort.function.test.ts
+++ b/test/ordering/sort.function.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { equivalence, sort } from '../../src';
-import { NumberTestSets } from '../util/test-sets/number-test-sets.model';
-import { StringTestSets } from '../util/test-sets/string-test-sets.model';
-import { SymbolTestSets } from '../util/test-sets/symbol-test-sets.model';
 import { TestSets } from '../util/test-sets/test-sets.model';
+import { testSuite } from '../util/test-suite.function';
 
 describe('sort', () => {
-	describe('sort ⋅ number', () => sortTests(new NumberTestSets()));
-	describe('sort ⋅ string', () => sortTests(new StringTestSets()));
-	describe('sort ⋅ symbol', () => sortTests(new SymbolTestSets()));
+	testSuite('sort', sortTests);
 });
 
 function sortTests<T>(testSets: TestSets<T>): void {
@@ -20,7 +16,7 @@ function sortTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
-	if (typeof a === 'number' || typeof a === 'string') {
+	if (testSets.canSortWithoutComparator) {
 		it('sorting a set returns an equivalent set', () => {
 			const result = sort(setA);
 			expect(equivalence(result, setA)).toBe(true);
@@ -39,7 +35,7 @@ function sortTests<T>(testSets: TestSets<T>): void {
 		expectSortedElements(result, ordered);
 	});
 
-	if (typeof a === 'number' || typeof a === 'string') {
+	if (testSets.willSortWithoutComparator) {
 		it('sorting an unordered set will order it', () => {
 			const ordered = Array.from(universal);
 			const result = sort(unordered);

--- a/test/util/test-sets/array-test-sets.model.ts
+++ b/test/util/test-sets/array-test-sets.model.ts
@@ -1,0 +1,9 @@
+import { TestSets } from './test-sets.model';
+
+type TestArray = [ number ];
+
+export class ArrayTestSets extends TestSets<TestArray> {
+	public constructor() {
+		super([ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], [ 9 ]);
+	}
+}

--- a/test/util/test-sets/date-test-sets.model.ts
+++ b/test/util/test-sets/date-test-sets.model.ts
@@ -1,0 +1,21 @@
+import { TestSets } from './test-sets.model';
+
+export class DateTestSets extends TestSets<Date> {
+
+	public override readonly willSortWithoutComparator = false;
+
+	public constructor() {
+		super(
+			new Date(0),
+			new Date(1),
+			new Date(2),
+			new Date(3),
+			new Date(4),
+			new Date(5),
+			new Date(6),
+			new Date(7),
+			new Date(8),
+			new Date(9),
+		);
+	}
+}

--- a/test/util/test-sets/enum-test-sets.model.ts
+++ b/test/util/test-sets/enum-test-sets.model.ts
@@ -1,0 +1,20 @@
+import { TestSets } from './test-sets.model';
+
+enum TestEnum { A, B, C, D, E, F, G, H, I, J }
+
+export class EnumTestSets extends TestSets<TestEnum> {
+	public constructor() {
+		super(
+			TestEnum.A,
+			TestEnum.B,
+			TestEnum.C,
+			TestEnum.D,
+			TestEnum.E,
+			TestEnum.F,
+			TestEnum.G,
+			TestEnum.H,
+			TestEnum.I,
+			TestEnum.J,
+		);
+	}
+}

--- a/test/util/test-sets/error-test-sets.model.ts
+++ b/test/util/test-sets/error-test-sets.model.ts
@@ -1,0 +1,18 @@
+import { TestSets } from './test-sets.model';
+
+export class ErrorTestSets extends TestSets<Error> {
+	public constructor() {
+		super(
+			new Error('a'),
+			new Error('b'),
+			new Error('c'),
+			new Error('d'),
+			new Error('e'),
+			new Error('f'),
+			new Error('g'),
+			new Error('h'),
+			new Error('i'),
+			new Error('j'),
+		);
+	}
+}

--- a/test/util/test-sets/function-test-sets.model.ts
+++ b/test/util/test-sets/function-test-sets.model.ts
@@ -1,0 +1,20 @@
+import { TestSets } from './test-sets.model';
+
+type TestFunction = () => number;
+
+export class FunctionTestSets extends TestSets<TestFunction> {
+	public constructor() {
+		super(
+			() => 0,
+			() => 1,
+			() => 2,
+			() => 3,
+			() => 4,
+			() => 5,
+			() => 6,
+			() => 7,
+			() => 8,
+			() => 9,
+		);
+	}
+}

--- a/test/util/test-sets/map-test-sets.model.ts
+++ b/test/util/test-sets/map-test-sets.model.ts
@@ -1,0 +1,31 @@
+import { TestSets } from './test-sets.model';
+
+type TestMap = Map<'id', number>;
+
+export class MapTestSets extends TestSets<TestMap> {
+
+	public override readonly willSortWithoutComparator = false;
+
+	public constructor() {
+		super(
+			new Map([[ 'id', 0 ]]),
+			new Map([[ 'id', 1 ]]),
+			new Map([[ 'id', 2 ]]),
+			new Map([[ 'id', 3 ]]),
+			new Map([[ 'id', 4 ]]),
+			new Map([[ 'id', 5 ]]),
+			new Map([[ 'id', 6 ]]),
+			new Map([[ 'id', 7 ]]),
+			new Map([[ 'id', 8 ]]),
+			new Map([[ 'id', 9 ]]),
+		);
+	}
+
+	public override defaultComparator(first: TestMap, second: TestMap): number {
+		return (first.get('id')! < second.get('id')!) ? -1 : 1;
+	}
+
+	public override reverseComparator(first: TestMap, second: TestMap): number {
+		return (first.get('id')! < second.get('id')!) ? 1 : -1;
+	}
+}

--- a/test/util/test-sets/object-test-sets.model.ts
+++ b/test/util/test-sets/object-test-sets.model.ts
@@ -1,0 +1,31 @@
+import { TestSets } from './test-sets.model';
+
+type TestObject = { readonly id: number };
+
+export class ObjectTestSets extends TestSets<TestObject> {
+
+	public override readonly willSortWithoutComparator = false;
+
+	public constructor() {
+		super(
+			{ id: 0 },
+			{ id: 1 },
+			{ id: 2 },
+			{ id: 3 },
+			{ id: 4 },
+			{ id: 5 },
+			{ id: 6 },
+			{ id: 7 },
+			{ id: 8 },
+			{ id: 9 },
+		);
+	}
+
+	public override defaultComparator(first: TestObject, second: TestObject): number {
+		return (first.id < second.id) ? -1 : 1;
+	}
+
+	public override reverseComparator(first: TestObject, second: TestObject): number {
+		return (first.id < second.id) ? 1 : -1;
+	}
+}

--- a/test/util/test-sets/reg-exp-test-sets.model.ts
+++ b/test/util/test-sets/reg-exp-test-sets.model.ts
@@ -1,0 +1,7 @@
+import { TestSets } from './test-sets.model';
+
+export class RegExpTestSets extends TestSets<RegExp> {
+	public constructor() {
+		super(/a/, /b/, /c/, /d/, /e/, /f/, /g/, /h/, /i/, /j/);
+	}
+}

--- a/test/util/test-sets/set-test-sets.model.ts
+++ b/test/util/test-sets/set-test-sets.model.ts
@@ -1,0 +1,31 @@
+import { TestSets } from './test-sets.model';
+
+type TestSet = Set<number>;
+
+export class SetTestSets extends TestSets<TestSet> {
+
+	public override readonly willSortWithoutComparator = false;
+
+	public constructor() {
+		super(
+			new Set([ 0 ]),
+			new Set([ 1 ]),
+			new Set([ 2 ]),
+			new Set([ 3 ]),
+			new Set([ 4 ]),
+			new Set([ 5 ]),
+			new Set([ 6 ]),
+			new Set([ 7 ]),
+			new Set([ 8 ]),
+			new Set([ 9 ]),
+		);
+	}
+
+	public override defaultComparator(first: TestSet, second: TestSet): number {
+		return (first.values().next().value < second.values().next().value) ? -1 : 1;
+	}
+
+	public override reverseComparator(first: TestSet, second: TestSet): number {
+		return (first.values().next().value < second.values().next().value) ? 1 : -1;
+	}
+}

--- a/test/util/test-sets/symbol-test-sets.model.ts
+++ b/test/util/test-sets/symbol-test-sets.model.ts
@@ -1,6 +1,10 @@
 import { TestSets } from './test-sets.model';
 
 export class SymbolTestSets extends TestSets<symbol> {
+
+	public override readonly canSortWithoutComparator = false;
+	public override readonly willSortWithoutComparator = false;
+
 	public constructor() {
 		super(
 			Symbol('a'),

--- a/test/util/test-sets/test-sets.model.ts
+++ b/test/util/test-sets/test-sets.model.ts
@@ -53,6 +53,11 @@ export abstract class TestSets<T> {
 	/* unique to: setF */
 	public readonly j: T;
 
+	/* whether the sort tests can run without a comparator */
+	public readonly canSortWithoutComparator: boolean = true;
+	/* whether the sort tests will sort correctly without a comparator */
+	public readonly willSortWithoutComparator: boolean = true;
+
 	protected constructor(a: T, b: T, c: T, d: T, e: T, f: T, g: T, h: T, i: T, j: T) {
 		this.empty = new Set<never>();
 		this.universal = new Set<T>([ a, b, c, d, e, f, g, h, i, j ]);

--- a/test/util/test-suite.function.ts
+++ b/test/util/test-suite.function.ts
@@ -1,0 +1,29 @@
+import { describe } from '@jest/globals';
+import { ArrayTestSets } from './test-sets/array-test-sets.model';
+import { DateTestSets } from './test-sets/date-test-sets.model';
+import { EnumTestSets } from './test-sets/enum-test-sets.model';
+import { ErrorTestSets } from './test-sets/error-test-sets.model';
+import { FunctionTestSets } from './test-sets/function-test-sets.model';
+import { MapTestSets } from './test-sets/map-test-sets.model';
+import { NumberTestSets } from './test-sets/number-test-sets.model';
+import { ObjectTestSets } from './test-sets/object-test-sets.model';
+import { RegExpTestSets } from './test-sets/reg-exp-test-sets.model';
+import { SetTestSets } from './test-sets/set-test-sets.model';
+import { StringTestSets } from './test-sets/string-test-sets.model';
+import { SymbolTestSets } from './test-sets/symbol-test-sets.model';
+import { TestSets } from './test-sets/test-sets.model';
+
+export function testSuite(name: string, tests: (testSets: TestSets<unknown>) => void): void {
+	describe(`${ name } ⋅ array`, () => tests(new ArrayTestSets()));
+	describe(`${ name } ⋅ date`, () => tests(new DateTestSets()));
+	describe(`${ name } ⋅ enum`, () => tests(new EnumTestSets()));
+	describe(`${ name } ⋅ error`, () => tests(new ErrorTestSets()));
+	describe(`${ name } ⋅ function`, () => tests(new FunctionTestSets()));
+	describe(`${ name } ⋅ map`, () => tests(new MapTestSets()));
+	describe(`${ name } ⋅ number`, () => tests(new NumberTestSets()));
+	describe(`${ name } ⋅ object`, () => tests(new ObjectTestSets()));
+	describe(`${ name } ⋅ regexp`, () => tests(new RegExpTestSets()));
+	describe(`${ name } ⋅ set`, () => tests(new SetTestSets()));
+	describe(`${ name } ⋅ string`, () => tests(new StringTestSets()));
+	describe(`${ name } ⋅ symbol`, () => tests(new SymbolTestSets()));
+}


### PR DESCRIPTION
As a followup to #59, where we split the concrete unit tests into generic implementations. This adds implementations of `TestSets<>` for each of the JS and TS builtins:
1. `ArrayTestSets extends TestSets<Array>`
2. `DateTestSets extends TestSets<Date>`
3. `EnumTestSets extends TestSets<Enum>`
4. `ErrorTestSets extends TestSets<Error>`
5. `FunctionTestSets extends TestSets<Function>`
6. `MapTestSets extends TestSets<Map>`
7. `ObjectTestSets extends TestSets<Object>`
8. `RegExpTestSets extends TestSets<RegExp>`
9. `SetTestSets extends TestSets<Set>`