### PR TITLE
improved pairwiseDisjoint performance

### DIFF
--- a/src/comparisons/pairwise-disjoint.function.ts
+++ b/src/comparisons/pairwise-disjoint.function.ts
@@ -15,7 +15,19 @@ export function pairwiseDisjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boo
 		return true;
 	}
 
-	const allElements = new Set<T>(sets.shift());
+	const primarySet = sets.shift()!;
+	const secondarySet = sets.shift()!;
+	for (const element of secondarySet) {
+		if (primarySet.has(element)) {
+			return false;
+		}
+	}
+
+	if (sets.length === 0) {
+		return true;
+	}
+
+	const allElements = new Set<T>([ ...primarySet, ...secondarySet ]);
 	for (const set of sets) {
 		for (const element of set) {
 			if (allElements.has(element)) {


### PR DESCRIPTION
### improved `pairwiseDisjoint` performance:
Added a preface to `pairwiseDisjoint`, which evaluates the first 2 sets against each other, before creating an `allElements` set. Thereby, we can evaluate for equivalent values immediately, without wasting time copying. And only after those first 2 sets are shown to be disjoint do we create a disjoint union, and continue evaluating.

This improves the `pairwiseDisjoint` function tremendously at scale, when rendering false results. The scale tests show that when evaluating low numbers of input sets, and expecting a false result, `pairwiseDisjoint`'s performance improved by at least 60% for all cases. And all of the worst case scenario tests put it well past a 99% time reduction.

Meanwhile, for the expected true cases, where the input sets are all indeed pairwise disjoint, the timing remains consistent to within 2% of the original code.

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[original] raw data:</h4></summary>

|              | pwdj(of1)   | pwdj(of1, of1) | pwdj(of1, of2) | pwdj(of2, of1) | pwdj(of1, of1, of1) | pwdj(of1, of2, of3) | pwdj(of3, of2, of1) |
|:-------------|:------------|:---------------|:---------------|:---------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 0.121ms     | 4616.321ms     | 5212.080ms     | 2191.888ms     | 4752.401ms          | 4857.238ms          | 1499.582ms          |
| test 2:      | 0.121ms     | 4616.217ms     | 4754.881ms     | 2043.206ms     | 4283.293ms          | 4695.374ms          | 1418.194ms          |
| test 3:      | 0.076ms     | 4870.573ms     | 4523.984ms     | 2188.633ms     | 4534.958ms          | 4699.525ms          | 1462.781ms          |
| test 4:      | 0.068ms     | 4779.581ms     | 4251.215ms     | 2215.621ms     | 4407.859ms          | 4284.716ms          | 1456.211ms          |
| test 5:      | 0.073ms     | 4647.334ms     | 4738.660ms     | 2171.088ms     | 4615.125ms          | 4688.970ms          | 1413.700ms          |
|              |
| **average:** | **0.092ms** | **4706.005ms** | **4696.164ms** | **2162.087ms** | **4518.727ms**      | **4645.165ms**      | **1450.094ms**      |

|              | pwdj(100 Eq) | pwdj(10k Eq) | pwdj(100 Dj)   | pwdj(10k Dj)   |
|:-------------|:-------------|:-------------|:---------------|:---------------|
| test 1:      | 11.581ms     | 0.139ms      | 3192.462ms     | 3441.889ms     |
| test 2:      | 11.584ms     | 0.139ms      | 3309.798ms     | 3682.435ms     |
| test 3:      | 11.493ms     | 0.155ms      | 3333.312ms     | 3430.862ms     |
| test 4:      | 11.748ms     | 0.133ms      | 3073.472ms     | 3421.060ms     |
| test 5:      | 11.749ms     | 0.157ms      | 3238.370ms     | 3416.453ms     |
|              |
| **average:** | **11.631ms** | **0.145ms**  | **3229.483ms** | **3478.540ms** |

|              | 100k ⋅ pwdj(2 Eq) | 100k ⋅ pwdj(5 Eq) | 100k ⋅ pwdj(2 Dj) | 100k ⋅ pwdj(5 Dj) |
|:-------------|:------------------|:------------------|:------------------|:------------------|
| test 1:      | 402.260ms         | 297.228ms         | 633.365ms         | 656.887ms         |
| test 2:      | 530.508ms         | 312.616ms         | 647.248ms         | 724.051ms         |
| test 3:      | 384.281ms         | 248.461ms         | 606.952ms         | 632.758ms         |
| test 4:      | 380.817ms         | 247.602ms         | 602.667ms         | 624.096ms         |
| test 5:      | 393.395ms         | 252.512ms         | 618.183ms         | 764.189ms         |
|              |
| **average:** | **418.252ms**     | **271.684ms**     | **621.683ms**     | **680.396ms**     |
</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[refactor] raw data:</h4></summary>

|              | pwdj(of1)   | pwdj(of1, of1) | pwdj(of1, of2) | pwdj(of2, of1) | pwdj(of1, of1, of1) | pwdj(of1, of2, of3) | pwdj(of3, of2, of1) |
|:-------------|:------------|:---------------|:---------------|:---------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 0.111ms     | 0.045ms        | 0.073ms        | 0.037ms        | 0.038ms             | 0.036ms             | 0.038ms             |
| test 2:      | 0.095ms     | 0.028ms        | 0.041ms        | 0.040ms        | 0.040ms             | 0.027ms             | 0.024ms             |
| test 3:      | 0.095ms     | 0.042ms        | 0.023ms        | 0.022ms        | 0.024ms             | 0.022ms             | 0.044ms             |
| test 4:      | 0.093ms     | 0.028ms        | 0.032ms        | 0.023ms        | 0.025ms             | 0.022ms             | 0.025ms             |
| test 5:      | 0.094ms     | 0.046ms        | 0.025ms        | 0.021ms        | 0.024ms             | 0.022ms             | 0.024ms             |
|              |
| **average:** | **0.098ms** | **0.038ms**    | **0.039ms**    | **0.029ms**    | **0.030ms**         | **0.026ms**         | **0.031ms**         |

|              | pwdj(100 Eq) | pwdj(10k Eq) | pwdj(100 Dj)   | pwdj(10k Dj)   |
|:-------------|:-------------|:-------------|:---------------|:---------------|
| test 1:      | 0.039ms      | 0.098ms      | 3339.116ms     | 3518.037ms     |
| test 2:      | 0.026ms      | 0.071ms      | 3204.100ms     | 3455.223ms     |
| test 3:      | 0.037ms      | 0.095ms      | 3331.485ms     | 3578.823ms     |
| test 4:      | 0.022ms      | 0.065ms      | 3274.879ms     | 3607.102ms     |
| test 5:      | 0.023ms      | 0.083ms      | 3401.351ms     | 3444.900ms     |
|              |
| **average:** | **0.029ms**  | **0.082ms**  | **3310.186ms** | **3520.817ms** |

|              | 100k ⋅ pwdj(2 Eq) | 100k ⋅ pwdj(5 Eq) | 100k ⋅ pwdj(2 Dj) | 100k ⋅ pwdj(5 Dj) |
|:-------------|:------------------|:------------------|:------------------|:------------------|
| test 1:      | 79.831ms          | 107.261ms         | 156.064ms         | 639.600ms         |
| test 2:      | 75.213ms          | 110.701ms         | 161.179ms         | 647.508ms         |
| test 3:      | 82.847ms          | 113.090ms         | 144.679ms         | 630.964ms         |
| test 4:      | 76.478ms          | 103.787ms         | 247.077ms         | 650.319ms         |
| test 5:      | 73.818ms          | 103.084ms         | 172.667ms         | 647.936ms         |
|              |
| **average:** | **77.637ms**      | **107.585ms**     | **176.333ms**     | **643.265ms**     |
</details>

<details open>
<summary><h4 style="display: inline; margin-bottom: 0;">[performance improvement] raw data:</h4></summary>

|                  | pwdj(of1)   | pwdj(of1, of1) | pwdj(of1, of2) | pwdj(of2, of1) | pwdj(of1, of1, of1) | pwdj(of1, of2, of3) | pwdj(of3, of2, of1) |
|:-----------------|:------------|:---------------|:---------------|:---------------|:--------------------|:--------------------|:--------------------|
| original:        | 0.092ms     | 4706.005ms     | 4696.164ms     | 2162.087ms     | 4518.727ms          | 4645.165ms          | 1450.094ms          |
| rewrite:         | 0.098ms     | 0.038ms        | 0.039ms        | 0.029ms        | 0.030ms             | 0.026ms             | 0.031ms             |
|                  |
| **improvement:** | **-6.521%** | **+99.999%**   | **+99.999%**   | **+99.999%**   | **+99.999%**        | **+99.999%**        | **+99.998%**        |

|                  | pwdj(100 Eq) | pwdj(10k Eq) | pwdj(100 Dj) | pwdj(10k Dj) |
|:-----------------|:-------------|:-------------|:-------------|:-------------|
| original:        | 11.631ms     | 0.145ms      | 3229.483ms   | 3478.540ms   |
| rewrite:         | 0.029ms      | 0.082ms      | 3310.186ms   | 3520.817ms   |
|                  |
| **improvement:** | **+99.751%** | **+43.448%** | **-2.499%**  | **-1.215%**  |

|                  | 100k ⋅ pwdj(2 Eq) | 100k ⋅ pwdj(5 Eq) | 100k ⋅ pwdj(2 Dj) | 100k ⋅ pwdj(5 Dj) |
|:-----------------|:------------------|:------------------|:------------------|:------------------|
| original:        | 418.252ms         | 271.684ms         | 621.683ms         | 680.396ms         |
| rewrite:         | 77.637ms          | 107.585ms         | 176.333ms         | 643.265ms         |
|                  |
| **improvement:** | **+81.438%**      | **+60.401%**      | **+71.636%**      | **+5.457%**       |
</details>
