### PR TITLE
added many sets unit tests

### DIFF
--- a/test/comparisons/disjoint.function.test.ts
+++ b/test/comparisons/disjoint.function.test.ts
@@ -22,8 +22,12 @@ function disjointTests<T>(testSets: TestSets<T>): void {
 		expect(disjoint(setA, setA)).toBe(false);
 	});
 
-	it('many of the same set are not disjoint', () => {
+	it('three of the same set are not disjoint', () => {
 		expect(disjoint(setA, setA, setA)).toBe(false);
+	});
+
+	it('many of the same set are not disjoint', () => {
+		expect(disjoint(setA, setA, setA, setA, setA, setA)).toBe(false);
 	});
 
 	it('two sets with some shared elements are not disjoint', () => {
@@ -34,8 +38,12 @@ function disjointTests<T>(testSets: TestSets<T>): void {
 		expect(disjoint(setA, setB, setC)).toBe(false);
 	});
 
-	it('many sets with some shared elements are not disjoint', () => {
+	it('many sets with some shared elements of the first are not disjoint', () => {
 		expect(disjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with no shared elements of the first are disjoint', () => {
+		expect(disjoint(setF, setE, setD, setC, setB, setA)).toBe(true);
 	});
 
 	it('any non-empty set and the empty set are disjoint', () => {

--- a/test/comparisons/equivalence.function.test.ts
+++ b/test/comparisons/equivalence.function.test.ts
@@ -22,8 +22,12 @@ function equivalenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(setA, setA)).toBe(true);
 	});
 
-	it('many of the same set are equivalent', () => {
+	it('three of the same set are equivalent', () => {
 		expect(equivalence(setA, setA, setA)).toBe(true);
+	});
+
+	it('many of the same set are equivalent', () => {
+		expect(equivalence(setA, setA, setA, setA, setA, setA)).toBe(true);
 	});
 
 	it('two different sets are not equivalent', () => {
@@ -36,6 +40,10 @@ function equivalenceTests<T>(testSets: TestSets<T>): void {
 
 	it('many different sets are not equivalent', () => {
 		expect(equivalence(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many different sets (reversed) are not equivalent', () => {
+		expect(equivalence(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set and the empty set are not equivalent', () => {

--- a/test/comparisons/pairwise-disjoint.function.test.ts
+++ b/test/comparisons/pairwise-disjoint.function.test.ts
@@ -22,8 +22,12 @@ function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {
 		expect(pairwiseDisjoint(setA, setA)).toBe(false);
 	});
 
-	it('many of the same set are not pairwise disjoint', () => {
+	it('three of the same set are not pairwise disjoint', () => {
 		expect(pairwiseDisjoint(setA, setA, setA)).toBe(false);
+	});
+
+	it('many of the same set are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setA, setA, setA, setA, setA)).toBe(false);
 	});
 
 	it('two sets with some shared elements are not pairwise disjoint', () => {
@@ -36,6 +40,10 @@ function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets with some shared elements are not pairwise disjoint', () => {
 		expect(pairwiseDisjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with some shared elements are not pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set and the empty set are pairwise disjoint', () => {

--- a/test/comparisons/proper-subset.function.test.ts
+++ b/test/comparisons/proper-subset.function.test.ts
@@ -22,8 +22,12 @@ function properSubsetTests<T>(testSets: TestSets<T>): void {
 		expect(properSubset(setA, setA)).toBe(false);
 	});
 
-	it('many of the same set are not proper subsets', () => {
+	it('three of the same set are not proper subsets', () => {
 		expect(properSubset(setA, setA, setA)).toBe(false);
+	});
+
+	it('many of the same set are not proper subsets', () => {
+		expect(properSubset(setA, setA, setA, setA, setA, setA)).toBe(false);
 	});
 
 	it('two sets with different elements are not proper subsets', () => {
@@ -36,6 +40,10 @@ function properSubsetTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets with different elements are not proper subsets', () => {
 		expect(properSubset(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with different elements are not proper subsets', () => {
+		expect(properSubset(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set is not a proper subset of the empty set', () => {

--- a/test/comparisons/proper-superset.function.test.ts
+++ b/test/comparisons/proper-superset.function.test.ts
@@ -22,8 +22,12 @@ function properSupersetTests<T>(testSets: TestSets<T>): void {
 		expect(properSuperset(setA, setA)).toBe(false);
 	});
 
-	it('many of the same set are not proper supersets', () => {
+	it('three of the same set are not proper supersets', () => {
 		expect(properSuperset(setA, setA, setA)).toBe(false);
+	});
+
+	it('many of the same set are not proper supersets', () => {
+		expect(properSuperset(setA, setA, setA, setA, setA, setA)).toBe(false);
 	});
 
 	it('two sets with different elements are not proper supersets', () => {
@@ -36,6 +40,10 @@ function properSupersetTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets with different elements are not proper supersets', () => {
 		expect(properSuperset(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with different elements are not proper supersets', () => {
+		expect(properSuperset(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set is a proper superset of the empty set', () => {

--- a/test/comparisons/subset.function.test.ts
+++ b/test/comparisons/subset.function.test.ts
@@ -22,8 +22,12 @@ function subsetTests<T>(testSets: TestSets<T>): void {
 		expect(subset(setA, setA)).toBe(true);
 	});
 
-	it('many of the same set are subsets', () => {
+	it('three of the same set are subsets', () => {
 		expect(subset(setA, setA, setA)).toBe(true);
+	});
+
+	it('many of the same set are subsets', () => {
+		expect(subset(setA, setA, setA, setA, setA, setA)).toBe(true);
 	});
 
 	it('two sets with different elements are not subsets', () => {
@@ -36,6 +40,10 @@ function subsetTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets with different elements are not subsets', () => {
 		expect(subset(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with different elements are not subsets', () => {
+		expect(subset(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set is not a subset of the empty set', () => {

--- a/test/comparisons/superset.function.test.ts
+++ b/test/comparisons/superset.function.test.ts
@@ -22,8 +22,12 @@ function supersetTests<T>(testSets: TestSets<T>): void {
 		expect(superset(setA, setA)).toBe(true);
 	});
 
-	it('many of the same set are supersets', () => {
+	it('three of the same set are supersets', () => {
 		expect(superset(setA, setA, setA)).toBe(true);
+	});
+
+	it('many of the same set are supersets', () => {
+		expect(superset(setA, setA, setA, setA, setA, setA)).toBe(true);
 	});
 
 	it('two sets with different elements are not supersets', () => {
@@ -36,6 +40,10 @@ function supersetTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets with different elements are not supersets', () => {
 		expect(superset(setA, setB, setC, setD, setE, setF)).toBe(false);
+	});
+
+	it('many sets (reversed) with different elements are not supersets', () => {
+		expect(superset(setF, setE, setD, setC, setB, setA)).toBe(false);
 	});
 
 	it('any non-empty set is a superset of the empty set', () => {

--- a/test/operations/difference.function.test.ts
+++ b/test/operations/difference.function.test.ts
@@ -27,8 +27,13 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
-	it('many of the same set has no difference overlap', () => {
+	it('three of the same set has no difference overlap', () => {
 		const result = difference(setA, setA, setA);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('many of the same set has no difference overlap', () => {
+		const result = difference(setA, setA, setA, setA, setA, setA);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
@@ -45,6 +50,11 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 	it('many sets\' difference is a subset of the first', () => {
 		const result = difference(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, differenceABC)).toBe(true);
+	});
+
+	it('many sets\' (reversed) difference is a subset of the first', () => {
+		const result = difference(setF, setE, setD, setC, setB, setA);
+		expect(equivalence(result, setF)).toBe(true);
 	});
 
 	it('any sets\' difference with the empty set is itself', () => {

--- a/test/operations/intersection.function.test.ts
+++ b/test/operations/intersection.function.test.ts
@@ -27,8 +27,13 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, setA)).toBe(true);
 	});
 
-	it('many of the same set intersection returns self', () => {
+	it('three of the same set intersection returns self', () => {
 		const result = intersection(setA, setA, setA);
+		expect(equivalence(result, setA)).toBe(true);
+	});
+
+	it('many of the same set intersection returns self', () => {
+		const result = intersection(setA, setA, setA, setA, setA, setA);
 		expect(equivalence(result, setA)).toBe(true);
 	});
 
@@ -44,6 +49,11 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets\' intersection is a subset of the first', () => {
 		const result = intersection(setA, setB, setC, setD, setE, setF);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('many sets\' (reversed) intersection is a subset of the first', () => {
+		const result = intersection(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 

--- a/test/operations/union.function.test.ts
+++ b/test/operations/union.function.test.ts
@@ -27,8 +27,13 @@ function unionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, setA)).toBe(true);
 	});
 
-	it('many of the same set union returns self', () => {
+	it('three of the same set union returns self', () => {
 		const result = union(setA, setA, setA);
+		expect(equivalence(result, setA)).toBe(true);
+	});
+
+	it('many of the same set union returns self', () => {
+		const result = union(setA, setA, setA, setA, setA, setA);
 		expect(equivalence(result, setA)).toBe(true);
 	});
 
@@ -44,6 +49,11 @@ function unionTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets\' union contains all elements from all sets', () => {
 		const result = union(setA, setB, setC, setD, setE, setF);
+		expect(equivalence(result, universal)).toBe(true);
+	});
+
+	it('many sets\' (reversed) union contains all elements from all sets', () => {
+		const result = union(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, universal)).toBe(true);
 	});
 

--- a/test/operations/xor.function.test.ts
+++ b/test/operations/xor.function.test.ts
@@ -29,8 +29,13 @@ function xorTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
-	it('many of the same set xor returns the empty set', () => {
+	it('three of the same set xor returns the empty set', () => {
 		const result = xor(setA, setA, setA);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('many of the same set xor returns the empty set', () => {
+		const result = xor(setA, setA, setA, setA, setA, setA);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
@@ -46,6 +51,11 @@ function xorTests<T>(testSets: TestSets<T>): void {
 
 	it('many different sets xor returns unique elements', () => {
 		const result = xor(setA, setB, setC, setD, setE, setF);
+		expect(equivalence(result, xorABCDEF)).toBe(true);
+	});
+
+	it('many different sets (reversed) xor returns unique elements', () => {
+		const result = xor(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, xorABCDEF)).toBe(true);
 	});
 

--- a/test/util/scale/timer.model.ts
+++ b/test/util/scale/timer.model.ts
@@ -31,7 +31,7 @@ export abstract class Timer {
 	public static log(methodName: string): void {
 		const logs = Timer.getLogs(methodName);
 
-		process.stdout.write(logs);
+		process.stdout.write(`${ logs }\n`);
 	}
 
 	public static logAll(): void {
@@ -39,7 +39,7 @@ export abstract class Timer {
 			.map(Timer.getLogs)
 			.join('');
 
-		process.stdout.write(logs);
+		process.stdout.write(`\n${ logs }\n`);
 	}
 
 	private static getLogs(methodName: string): string {


### PR DESCRIPTION
### added many sets unit tests:
Added two new tests to each of the `comparisons` and `operations` test suites:
- `many of the same set`: tests `function(6x setA)`
- `many sets (reversed)`: tests `function(setF, setE, setD, setC, setB, setA)`

### fixed spacing in scale tests output:
Added more newlines around the `process.stdout` calls.