### PR TITLE
pretty print timer output

### DIFF
--- a/test/scale/comparisons/disjoint.function.scale.test.ts
+++ b/test/scale/comparisons/disjoint.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { disjoint }  from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('disjoint @ scale', () => {
 
 	describe('disjoint ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('disjoint'));
 
 		it('disjoint(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('disjoint', () => disjoint(...someEquivalent));
@@ -70,6 +71,7 @@ describe('disjoint @ scale', () => {
 
 	describe('disjoint ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('disjoint'));
 
 		it('100k ⋅ disjoint(2 Equivalent):'.padEnd(padding), () => {
 			const disjointMock = jest.fn(disjoint);

--- a/test/scale/comparisons/equivalence.function.scale.test.ts
+++ b/test/scale/comparisons/equivalence.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { equivalence } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('equivalence @ scale', () => {
 
 	describe('equivalence ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('equivalence'));
 
 		it('equivalence(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('equivalence', () => equivalence(...someEquivalent));
@@ -70,6 +71,7 @@ describe('equivalence @ scale', () => {
 
 	describe('equivalence ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('equivalence'));
 
 		it('100k ⋅ equivalence(2 Equivalent):'.padEnd(padding), () => {
 			const equivalenceMock = jest.fn(equivalence);

--- a/test/scale/comparisons/pairwise-disjoint.function.scale.test.ts
+++ b/test/scale/comparisons/pairwise-disjoint.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { pairwiseDisjoint } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('pairwise disjoint @ scale', () => {
 
 	describe('pairwise disjoint ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('pairwiseDisjoint'));
 
 		it('pairwiseDisjoint(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(...someEquivalent));
@@ -70,6 +71,7 @@ describe('pairwise disjoint @ scale', () => {
 
 	describe('pairwise disjoint ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('pairwiseDisjoint'));
 
 		it('100k ⋅ pairwiseDisjoint(2 Equivalent):'.padEnd(padding), () => {
 			const pairwiseDisjointMock = jest.fn(pairwiseDisjoint);

--- a/test/scale/comparisons/proper-subset.function.scale.test.ts
+++ b/test/scale/comparisons/proper-subset.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { properSubset } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('proper subset @ scale', () => {
 
 	describe('proper subset ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSubset'));
 
 		it('properSubset(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('properSubset', () => properSubset(...someEquivalent));
@@ -70,6 +71,7 @@ describe('proper subset @ scale', () => {
 
 	describe('proper subset ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSubset'));
 
 		it('100k ⋅ properSubset(2 Equivalent):'.padEnd(padding), () => {
 			const properSubsetMock = jest.fn(properSubset);

--- a/test/scale/comparisons/proper-superset.function.scale.test.ts
+++ b/test/scale/comparisons/proper-superset.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { properSuperset } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('proper superset @ scale', () => {
 
 	describe('proper superset ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSuperset'));
 
 		it('properSuperset(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('properSuperset', () => properSuperset(...someEquivalent));
@@ -70,6 +71,7 @@ describe('proper superset @ scale', () => {
 
 	describe('proper superset ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSuperset'));
 
 		it('100k ⋅ properSuperset(2 Equivalent):'.padEnd(padding), () => {
 			const properSupersetMock = jest.fn(properSuperset);

--- a/test/scale/comparisons/subset.function.scale.test.ts
+++ b/test/scale/comparisons/subset.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { subset } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('subset @ scale', () => {
 
 	describe('subset ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('subset'));
 
 		it('subset(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('subset', () => subset(...someEquivalent));
@@ -70,6 +71,7 @@ describe('subset @ scale', () => {
 
 	describe('subset ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('subset'));
 
 		it('100k ⋅ subset(2 Equivalent):'.padEnd(padding), () => {
 			const subsetMock = jest.fn(subset);

--- a/test/scale/comparisons/superset.function.scale.test.ts
+++ b/test/scale/comparisons/superset.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { superset } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('superset @ scale', () => {
 
 	describe('superset ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('superset'));
 
 		it('superset(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('superset', () => superset(...someEquivalent));
@@ -70,6 +71,7 @@ describe('superset @ scale', () => {
 
 	describe('superset ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('superset'));
 
 		it('100k ⋅ superset(2 Equivalent):'.padEnd(padding), () => {
 			const supersetMock = jest.fn(superset);

--- a/test/scale/operations/difference.function.scale.test.ts
+++ b/test/scale/operations/difference.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { difference } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('difference @ scale', () => {
 
 	describe('difference ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('difference'));
 
 		it('difference(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('difference', () => difference(...someEquivalent));
@@ -70,6 +71,7 @@ describe('difference @ scale', () => {
 
 	describe('difference ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('difference'));
 
 		it('100k ⋅ difference(2 Equivalent):'.padEnd(padding), () => {
 			const differenceMock = jest.fn(difference);

--- a/test/scale/operations/intersection.function.scale.test.ts
+++ b/test/scale/operations/intersection.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { intersection } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('intersection @ scale', () => {
 
 	describe('intersection ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('intersection'));
 
 		it('intersection(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('intersection', () => intersection(...someEquivalent));
@@ -70,6 +71,7 @@ describe('intersection @ scale', () => {
 
 	describe('intersection ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('intersection'));
 
 		it('100k ⋅ intersection(2 Equivalent):'.padEnd(padding), () => {
 			const intersectionMock = jest.fn(intersection);

--- a/test/scale/operations/union.function.scale.test.ts
+++ b/test/scale/operations/union.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { union } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('union @ scale', () => {
 
 	describe('union ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('union'));
 
 		it('union(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('union', () => union(...someEquivalent));
@@ -70,6 +71,7 @@ describe('union @ scale', () => {
 
 	describe('union ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('union'));
 
 		it('100k ⋅ union(2 Equivalent):'.padEnd(padding), () => {
 			const unionMock = jest.fn(union);

--- a/test/scale/operations/xor.function.scale.test.ts
+++ b/test/scale/operations/xor.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { xor } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -46,6 +46,7 @@ describe('xor @ scale', () => {
 
 	describe('xor ⋅ many sets', () => {
 		const { manyDisjoint, manyEquivalent, someDisjoint, someEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('xor'));
 
 		it('xor(100 Equivalent):'.padEnd(padding), () => {
 			const result = Timer.time('xor', () => xor(...someEquivalent));
@@ -70,6 +71,7 @@ describe('xor @ scale', () => {
 
 	describe('xor ⋅ many times', () => {
 		const { coupleDisjoint, coupleEquivalent, fewDisjoint, fewEquivalent } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('xor'));
 
 		it('100k ⋅ xor(2 Equivalent):'.padEnd(padding), () => {
 			const xorMock = jest.fn(xor);

--- a/test/scale/ordering/sort.function.scale.test.ts
+++ b/test/scale/ordering/sort.function.scale.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { sort } from '../../../src';
 import { ScaleTestSets } from '../../util/scale/scale-test-sets.model';
 import { padding, times } from '../../util/scale/scale-test.constants';
@@ -59,6 +59,7 @@ describe('sort @ scale', () => {
 
 	describe('sort ⋅ many times', () => {
 		const { manyUnordered } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('sort'));
 
 		it('100k ⋅ sort(100):'.padEnd(padding), () => {
 			const sortMock = jest.fn(sort<number>);

--- a/test/util/scale/ansi-format.model.ts
+++ b/test/util/scale/ansi-format.model.ts
@@ -1,0 +1,58 @@
+abstract class AnsiEscapeSequences {
+
+	/* Foreground Colors */
+	public static readonly FG_BLACK = '\x1B[30m';
+	public static readonly FG_RED = '\x1B[31m';
+	public static readonly FG_GREEN = '\x1B[32m';
+	public static readonly FG_YELLOW = '\x1B[33m';
+	public static readonly FG_BLUE = '\x1B[34m';
+	public static readonly FG_MAGENTA = '\x1B[35m';
+	public static readonly FG_CYAN = '\x1B[36m';
+	public static readonly FG_WHITE = '\x1B[37m';
+
+	/* Resets */
+	public static readonly FG_OFF = '\x1B[39m';
+}
+
+export abstract class AnsiFormat {
+
+	public static fgBlack(text: string): string {
+		const { FG_BLACK, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_BLACK }${ text }${ FG_OFF }`;
+	}
+
+	public static fgRed(text: string): string {
+		const { FG_RED, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_RED }${ text }${ FG_OFF }`;
+	}
+
+	public static fgGreen(text: string): string {
+		const { FG_GREEN, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_GREEN }${ text }${ FG_OFF }`;
+	}
+
+	public static fgYellow(text: string): string {
+		const { FG_YELLOW, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_YELLOW }${ text }${ FG_OFF }`;
+	}
+
+	public static fgBlue(text: string): string {
+		const { FG_BLUE, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_BLUE }${ text }${ FG_OFF }`;
+	}
+
+	public static fgMagenta(text: string): string {
+		const { FG_MAGENTA, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_MAGENTA }${ text }${ FG_OFF }`;
+	}
+
+	public static fgCyan(text: string): string {
+		const { FG_CYAN, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_CYAN }${ text }${ FG_OFF }`;
+	}
+
+	public static fgWhite(text: string): string {
+		const { FG_WHITE, FG_OFF } = AnsiEscapeSequences;
+		return `${ FG_WHITE }${ text }${ FG_OFF }`;
+	}
+}

--- a/test/util/scale/scale-test-sets.model.ts
+++ b/test/util/scale/scale-test-sets.model.ts
@@ -22,6 +22,9 @@ import { Timer } from './timer.model';
  * ```
  */
 export abstract class ScaleTestSets {
+	private static hasFinishedCopyingMultiples = false;
+	private static hasFinishedCopyingMany = false;
+	private static copyingManyTimes = 0;
 
 	/* multiples of 1, contains (1 - 15M) */
 	public static readonly multiplesOf1 = ScaleTestSets.multiplesOf(1, 15_000_000);
@@ -63,7 +66,7 @@ export abstract class ScaleTestSets {
 	]);
 
 	private static multiplesOf(factor: number, size: number, offset = 0): ReadonlySet<number> {
-		return Timer.time('copying multiples', () =>
+		return Timer.time('copying sets', () =>
 			new Set<number>(Array.from(
 				{ length: size },
 				(_, index) => (index * factor) + offset),
@@ -71,7 +74,8 @@ export abstract class ScaleTestSets {
 	}
 
 	private static manyOf(quantity: number, size: number, offset = false): ReadonlyArray<ReadonlySet<number>> {
-		return Timer.time('copying many', () =>
+		ScaleTestSets.incrementTimer();
+		return Timer.time('copying sets', () =>
 			Array.from(
 				{ length: quantity },
 				(_1, setIndex) => new Set<number>(Array.from(
@@ -79,6 +83,20 @@ export abstract class ScaleTestSets {
 					(_2, index) => index + (offset ? (setIndex * size) : 0),
 				)),
 			));
+	}
+
+	private static incrementTimer(): void {
+		if (!ScaleTestSets.hasFinishedCopyingMultiples) {
+			ScaleTestSets.hasFinishedCopyingMultiples = true;
+			Timer.nextLine('copying sets');
+		}
+
+		if (!ScaleTestSets.hasFinishedCopyingMany) {
+			if (ScaleTestSets.copyingManyTimes++ === 4) {
+				ScaleTestSets.hasFinishedCopyingMany = true;
+				Timer.nextLine('copying sets');
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### Improved Horizontal Logging:
Instead of printing every scale test time in one line, they are now separated into line-broken regions. So, most of the scale test suites now output 3 lines, for the `large sets`, `many sets`, and `many times` tests are visually separated into different lines.

### Added ANSI Color Formatting:
Well, the GitHub actions are surely unlikely to report the ANSI colors, we already see this.

But for local runs, the timings are now colored by their relative performance. In order of best to worst performance, the timings are colored as: `purple → blue → green → yellow → red → black`. This gives an at-a-glance view of which tests are most performant, and likewise, which are worst performant.
