### PR TITLE
improved difference performance

### DIFF
--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -11,7 +11,19 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∖ B ≔ { x : (x ∈ A) ∧ (x ∉ B) }
  */
 export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const resultSet = new Set<T>(sets.shift());
+	if (sets.length < 2) {
+		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+	}
+
+	const resultSet = new Set<T>();
+	const primarySet = sets.shift()!;
+	const secondarySet = sets.shift()!;
+
+	for (const element of primarySet) {
+		if (!secondarySet.has(element)) {
+			resultSet.add(element);
+		}
+	}
 
 	for (const set of sets) {
 		for (const element of set) {


### PR DESCRIPTION
### improved `difference` performance:

Added a preface to `difference`, which compares elements in the first 2 sets to create the initial `resultSet`.

This improves the `difference` function significantly at scale, when comparing sets with many shared elements. Because, there is no time wasted adding elements to the `resultSet` which are immediately removed, on the first comparison. 

The scale tests show that when taking the `difference` of equivalent sets, we see a performance improvement of ~70 - 80%. And, somewhat surprisingly, even when taking the `difference` of disjoint sets we see a performance improvement of ~15%.

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[original] raw data:</h4></summary>

|              | diff(of1)       | diff(of1, of1)  | diff(of1, of2)  | diff(of2, of1)  | diff(of1, of1, of1) | diff(of1, of2, of3) | diff(of3, of2, of1) |
|:-------------|:----------------|:----------------|:----------------|:----------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 4,418.550ms     | 7,884.820ms     | 5,641.005ms     | 4,805.815ms     | 7,815.649ms         | 6,609.388ms         | 4,416.912ms         |
| test 2:      | 4,788.018ms     | 8,223.485ms     | 5,840.107ms     | 4,867.851ms     | 7,715.026ms         | 6,836.556ms         | 4,395.421ms         |
| test 3:      | 4,823.249ms     | 8,479.529ms     | 6,020.199ms     | 4,757.042ms     | 7,823.410ms         | 6,841.402ms         | 4,496.853ms         |
| test 4:      | 4,830.184ms     | 8,075.906ms     | 5,998.623ms     | 5,101.661ms     | 8,462.557ms         | 6,993.931ms         | 4,788.920ms         |
| test 5:      | 4,965.279ms     | 8,839.046ms     | 6,181.388ms     | 5,117.269ms     | 8,400.524ms         | 7,162.801ms         | 4,689.399ms         |
|              |
| **average:** | **4,765.056ms** | **8,300.557ms** | **5,936.264ms** | **4,929.928ms** | **8,043.433ms**     | **6,888.816ms**     | **4,557.501ms**     |

|              | diff(100 Eq)  | diff(10k Eq)  | diff(100 Dj)  | diff(10k Dj)  |
|:-------------|:--------------|:--------------|:--------------|:--------------|
| test 1:      | 141.117ms     | 127.458ms     | 486.858ms     | 290.433ms     |
| test 2:      | 126.728ms     | 130.839ms     | 668.434ms     | 306.223ms     |
| test 3:      | 166.302ms     | 119.147ms     | 483.108ms     | 372.857ms     |
| test 4:      | 128.808ms     | 121.328ms     | 624.014ms     | 306.245ms     |
| test 5:      | 135.751ms     | 118.487ms     | 569.261ms     | 391.225ms     |
|              |
| **average:** | **139.741ms** | **123.452ms** | **566.335ms** | **333.397ms** |

|              | 100k ⋅ diff(2 Eq) | 100k ⋅ diff(5 Eq) | 100k ⋅ diff(2 Dj) | 100k ⋅ diff(5 Dj) |
|:-------------|:------------------|:------------------|:------------------|:------------------|
| test 1:      | 543.797ms         | 433.343ms         | 534.138ms         | 408.758ms         |
| test 2:      | 547.231ms         | 416.417ms         | 505.280ms         | 402.499ms         |
| test 3:      | 540.191ms         | 401.920ms         | 553.465ms         | 399.718ms         |
| test 4:      | 579.906ms         | 443.260ms         | 541.264ms         | 439.411ms         |
| test 5:      | 602.899ms         | 443.683ms         | 560.087ms         | 468.310ms         |
|              |
| **average:** | **562.804ms**     | **427.725ms**     | **538.847**       | **423.739ms**     |
</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[refactor] raw data:</h4></summary>

|              | diff(of1)       | diff(of1, of1)  | diff(of1, of2)  | diff(of2, of1) | diff(of1, of1, of1) | diff(of1, of2, of3) | diff(of3, of2, of1) |
|:-------------|:----------------|:----------------|:----------------|:---------------|:--------------------|:--------------------|:--------------------|
| test 1:      | 4,711.144ms     | 1,966.826ms     | 3,760.383ms     | 882.037ms      | 2,086.930ms         | 4,581.015ms         | 3,387.557ms         |
| test 2:      | 4,738.123ms     | 1,955.410ms     | 3,654.271ms     | 877.717ms      | 2,076.653ms         | 4,525.640ms         | 3,325.482ms         |
| test 3:      | 4,573.159ms     | 1,949.007ms     | 3,691.006ms     | 873.589ms      | 2,159.398ms         | 4,431.261ms         | 3,115.491ms         |
| test 4:      | 4,404.468ms     | 2,010.612ms     | 3,686.942ms     | 870.008ms      | 2,083.314ms         | 4,618.425ms         | 3,141.082ms         |
| test 5:      | 4,531.998ms     | 1,979.808ms     | 3,697.941ms     | 882.143ms      | 2,053.703ms         | 4,492.147ms         | 3,183.774ms         |
|              |
| **average:** | **4,591.778ms** | **1,972.335ms** | **3,698.109ms** | **877.098ms**  | **2,092.000ms**     | **4,529.698ms**     | **3,230.677ms**     |

|              | diff(100 Eq)  | diff(10k Eq)  | diff(100 Dj)  | diff(10k Dj)  |
|:-------------|:--------------|:--------------|:--------------|:--------------|
| test 1:      | 111.830ms     | 113.062ms     | 507.995ms     | 273.702ms     |
| test 2:      | 112.235ms     | 110.271ms     | 453.632ms     | 296.232ms     |
| test 3:      | 112.766ms     | 122.102ms     | 435.313ms     | 266.474ms     |
| test 4:      | 109.938ms     | 116.534ms     | 417.165ms     | 271.646ms     |
| test 5:      | 122.378ms     | 124.848ms     | 494.463ms     | 283.859ms     |
|              |
| **average:** | **113.829ms** | **117.363ms** | **461.714ms** | **278.383ms** |

|              | 100k ⋅ diff(2 Eq) | 100k ⋅ diff(5 Eq) | 100k ⋅ diff(2 Dj) | 100k ⋅ diff(5 Dj) |
|:-------------|:------------------|:------------------|:------------------|:------------------|
| test 1:      | 184.565ms         | 233.013ms         | 407.986ms         | 326.257ms         |
| test 2:      | 194.033ms         | 237.751ms         | 395.348ms         | 343.444ms         |
| test 3:      | 187.302ms         | 240.464ms         | 473.824ms         | 345.909ms         |
| test 4:      | 182.420ms         | 236.994ms         | 408.838ms         | 419.102ms         |
| test 5:      | 184.162ms         | 258.414ms         | 409.742ms         | 355.942ms         |
|              |
| **average:** | **186.496ms**     | **241.327ms**     | **419.148ms**     | **358.131ms**     |
</details>

<details open>
<summary><h4 style="display: inline; margin-bottom: 0;">[performance improvement] raw data:</h4></summary>

|                  | diff(of1)   | diff(of1, of1) | diff(of1, of2) | diff(of2, of1) | diff(of1, of1, of1) | diff(of1, of2, of3) | diff(of3, of2, of1) |
|:-----------------|:------------|:---------------|:---------------|:---------------|:--------------------|:--------------------|:--------------------|
| original:        | 4,765.056ms | 8,300.557ms    | 5,936.264ms    | 4,929.928ms    | 8,043.433ms         | 6,888.816ms         | 4,557.501ms         |
| rewrite:         | 4,591.778ms | 1,972.335ms    | 3,698.109ms    | 877.098ms      | 2,092.000ms         | 4,529.698ms         | 3,230.677ms         |
|                  |
| **improvement:** | **+3.636%** | **+76.239%**   | **+37.703%**   | **+82.209%**   | **+73.991%**        | **+34.246%**        | **+29.113%**        |

|                  | diff(100 Eq) | diff(10k Eq) | diff(100 Dj) | diff(10k Dj) |
|:-----------------|:-------------|:-------------|:-------------|:-------------|
| original:        | 139.741ms    | 123.452ms    | 566.335ms    | 333.397ms    |
| rewrite:         | 113.829ms    | 117.363ms    | 461.714ms    | 278.383ms    |
|                  |
| **improvement:** | **+18.543%** | **+4.932%**  | **+18.473%** | **+16.501%** |

|                  | 100k ⋅ diff(2 Eq) | 100k ⋅ diff(5 Eq) | 100k ⋅ diff(2 Dj) | 100k ⋅ diff(5 Dj) |
|:-----------------|:------------------|:------------------|:------------------|:------------------|
| original:        | 562.804ms         | 427.725ms         | 538.847           | 423.739ms         |
| rewrite:         | 186.496ms         | 241.327ms         | 419.148ms         | 358.131ms         |
|                  |
| **improvement:** | **+66.863%**      | **+43.579%**      | **+22.214%**      | **+15.483%**      |
</details>
