### PR TITLE
improved intersection performance

### DIFF
--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -9,7 +9,19 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
 export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const resultSet = new Set<T>(sets.shift());
+	if (sets.length < 2) {
+		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+	}
+
+	const resultSet = new Set<T>();
+	const primarySet = sets.shift()!;
+	const secondarySet = sets.shift()!;
+
+	for (const element of primarySet) {
+		if (secondarySet.has(element)) {
+			resultSet.add(element);
+		}
+	}
 
 	for (const set of sets) {
 		for (const element of resultSet) {


### PR DESCRIPTION
### improved `intersection` performance:

Added a preface to `intersection`, which compares elements in the first 2 sets to create the initial `resultSet`.

This improves the `intersection` function significantly at scale, when comparing sets with few shared elements. Because, there is no time wasted adding elements to the `resultSet` which are immediately removed, on the first comparison. 

The scale tests show that when taking the `intersection` of disjoint sets, we see a performance improvement of ~50 - 80%. And, somewhat surprisingly, even when taking the `intersection` of equivalent sets we see a performance improvement of ~10 - 30%.

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[original] raw data:</h4></summary>

|              | inter(of1)      | inter(of1, of1) | inter(of1, of2) | inter(of2, of1) | inter(of1, of1, of1) | inter(of1, of2, of3) | inter(of3, of2, of1) |
|:-------------|:----------------|:----------------|:----------------|:----------------|:---------------------|:---------------------|:---------------------|
| test 1:      | 4,377.426ms     | 6,735.451ms     | 8,102.382ms     | 2,913.327ms     | 7,875.956ms          | 9,478.669ms          | 2,816.633ms          |
| test 2:      | 4,281.930ms     | 6,344.667ms     | 7,768.613ms     | 2,867.852ms     | 7,897.943ms          | 10,456.894ms         | 2,791.657ms          |
| test 3:      | 4,439.299ms     | 6,545.934ms     | 7,942.739ms     | 2,960.505ms     | 8,127.316ms          | 9,678.294ms          | 2,755.021ms          |
| test 4:      | 4,585.612ms     | 6,886.564ms     | 8,257.826ms     | 3,006.955ms     | 8,258.781ms          | 10,307.772ms         | 2,880.205ms          |
| test 5:      | 4,440.268ms     | 6,535.332ms     | 8,888.246ms     | 3,106.456ms     | 8,594.005ms          | 9,494.206ms          | 2,872.221ms          |
|              |
| **average:** | **4,424.907ms** | **6,609.590ms** | **8,191.961ms** | **2,971.019ms** | **8,150.800ms**      | **9,883.167ms**      | **2,823.147ms**      |

|              | inter(100 Eq) | inter(10k Eq) | inter(100 Dj) | inter(10k Dj) |
|:-------------|:--------------|:--------------|:--------------|:--------------|
| test 1:      | 410.190ms     | 247.237ms     | 22.539ms      | 0.340ms       |
| test 2:      | 403.356ms     | 247.404ms     | 30.472ms      | 0.407ms       |
| test 3:      | 430.968ms     | 252.189ms     | 21.216ms      | 0.294ms       |
| test 4:      | 418.326ms     | 278.742ms     | 37.885ms      | 0.447ms       |
| test 5:      | 418.847ms     | 239.853ms     | 21.692ms      | 0.370ms       |
|              |
| **average:** | **416.337ms** | **253.085ms** | **26.761ms**  | **0.372ms**   |

|              | 100k ⋅ inter(2 Eq) | 100k ⋅ inter(5 Eq) | 100k ⋅ inter(2 Dj) | 100k ⋅ inter(5 Dj) |
|:-------------|:-------------------|:-------------------|:-------------------|:-------------------|
| test 1:      | 527.243ms          | 402.482ms          | 568.494ms          | 419.922ms          |
| test 2:      | 751.326ms          | 414.826ms          | 618.579ms          | 354.918ms          |
| test 3:      | 569.956ms          | 480.491ms          | 583.028ms          | 357.983ms          |
| test 4:      | 632.521ms          | 430.562ms          | 588.263ms          | 351.663ms          |
| test 5:      | 498.057ms          | 400.427ms          | 607.304ms          | 382.176ms          |
|              |
| **average:** | **595.821ms**      | **425.758ms**      | **593.134ms**      | **373.332ms**      |
</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[refactor] raw data:</h4></summary>

|              | inter(of1)      | inter(of1, of1) | inter(of1, of2) | inter(of2, of1) | inter(of1, of1, of1) | inter(of1, of2, of3) | inter(of3, of2, of1) |
|:-------------|:----------------|:----------------|:----------------|:----------------|:---------------------|:---------------------|:---------------------|
| test 1:      | 4,322.983ms     | 5,693.015ms     | 3,602.305ms     | 2,501.756ms     | 7,228.035ms          | 5,554.182ms          | 1,537.629ms          |
| test 2:      | 4,449.666ms     | 5,507.669ms     | 3,856.591ms     | 2,646.234ms     | 7,721.171ms          | 5,962.953ms          | 1,574.496ms          |
| test 3:      | 4,405.531ms     | 5,541.553ms     | 3,593.993ms     | 2,537.991ms     | 7,086.961ms          | 5,502.272ms          | 1,567.400ms          |
| test 4:      | 4,341.720ms     | 5,423.862ms     | 3,671.896ms     | 2,690.478ms     | 7,159.097ms          | 5,619.187ms          | 1,498.521ms          |
| test 5:      | 4,420.132ms     | 5,601.589ms     | 3,666.507ms     | 2,515.135ms     | 8,065.955ms          | 5,737.136ms          | 1,552.612ms          |
|              |
| **average:** | **4,388.006ms** | **5,553.538ms** | **3,678.258ms** | **2,578.319ms** | **7,452.244ms**      | **5,675.146ms**      | **1,546.132ms**      |

|              | inter(100 Eq) | inter(10k Eq) | inter(100 Dj) | inter(10k Dj) |
|:-------------|:--------------|:--------------|:--------------|:--------------|
| test 1:      | 417.502ms     | 243.087ms     | 6.382ms       | 0.197ms       |
| test 2:      | 404.111ms     | 244.578ms     | 5.169ms       | 0.200ms       |
| test 3:      | 423.238ms     | 254.373ms     | 6.403ms       | 0.276ms       |
| test 4:      | 411.891ms     | 244.098ms     | 5.380ms       | 0.284ms       |
| test 5:      | 420.107ms     | 262.649ms     | 6.121ms       | 0.266ms       |
|              |
| **average:** | **415.370ms** | **249.757ms** | **5.891ms**   | **0.245ms**   |

|              | 100k ⋅ inter(2 Eq) | 100k ⋅ inter(5 Eq) | 100k ⋅ inter(2 Dj) | 100k ⋅ inter(5 Dj) |
|:-------------|:-------------------|:-------------------|:-------------------|:-------------------|
| test 1:      | 402.210ms          | 356.343ms          | 179.164ms          | 154.761ms          |
| test 2:      | 402.460ms          | 361.023ms          | 183.592ms          | 154.682ms          |
| test 3:      | 418.264ms          | 380.176ms          | 185.116ms          | 167.811ms          |
| test 4:      | 398.838ms          | 361.441ms          | 174.396ms          | 158.667ms          |
| test 5:      | 396.364ms          | 351.970ms          | 223.328ms          | 263.549ms          |
|              |
| **average:** | **403.627ms**      | **362.191ms**      | **189.119ms**      | **179.894ms**      |
</details>

<details open>
<summary><h4 style="display: inline; margin-bottom: 0;">[performance improvement] raw data:</h4></summary>

|                  | inter(of1)  | inter(of1, of1) | inter(of1, of2) | inter(of2, of1) | inter(of1, of1, of1) | inter(of1, of2, of3) | inter(of3, of2, of1) |
|:-----------------|:------------|:----------------|:----------------|:----------------|:---------------------|:---------------------|:---------------------|
| original:        | 4,424.907ms | 6,609.590ms     | 8,191.961ms     | 2,971.019ms     | 8,150.800ms          | 9,883.167ms          | 2,823.147ms          |
| rewrite:         | 4,388.006ms | 5,553.538ms     | 3,678.258ms     | 2,578.319ms     | 7,452.244ms          | 5,675.146ms          | 1,546.132ms          |
|                  |
| **improvement:** | **+0.834%** | **+15.978%**    | **+55.099%**    | **+13.218%**    | **+8.571%**          | **+42.578%**         | **+45.234%**         |

|                  | inter(100 Eq) | inter(10k Eq) | inter(100 Dj) | inter(10k Dj) |
|:-----------------|:--------------|:--------------|:--------------|:--------------|
| original:        | 416.337ms     | 253.085ms     | 26.761ms      | 0.372ms       |
| rewrite:         | 415.370ms     | 249.757ms     | 5.891ms       | 0.245ms       |
|                  |
| **improvement:** | **+0.232%**   | **+1.315%**   | **+77.987%**  | **+34.140%**  |

|                  | 100k ⋅ inter(2 Eq) | 100k ⋅ inter(5 Eq) | 100k ⋅ inter(2 Dj) | 100k ⋅ inter(5 Dj) |
|:-----------------|:-------------------|:-------------------|:-------------------|:-------------------|
| original:        | 595.821ms          | 425.758ms          | 593.134ms          | 373.332ms          |
| rewrite:         | 403.627ms          | 362.191ms          | 189.119ms          | 179.894ms          |
|                  |
| **improvement:** | **+32.257%**       | **+14.930%**       | **+68.115%**       | **+51.814%**       |
</details>
