### PR TITLE
added disjoint sets unit tests

### DIFF
--- a/test/unit/comparisons/disjoint.function.test.ts
+++ b/test/unit/comparisons/disjoint.function.test.ts
@@ -38,6 +38,14 @@ function disjointTests<T>(testSets: TestSets<T>): void {
 		expect(disjoint(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets with no shared elements are disjoint', () => {
+		expect(disjoint(setD, setE)).toBe(true);
+	});
+
+	it('three sets with no shared elements are disjoint', () => {
+		expect(disjoint(setD, setE, setF)).toBe(true);
+	});
+
 	it('many sets with some shared elements of the first are not disjoint', () => {
 		expect(disjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/comparisons/equivalence.function.test.ts
+++ b/test/unit/comparisons/equivalence.function.test.ts
@@ -30,12 +30,20 @@ function equivalenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(setA, setA, setA, setA, setA, setA)).toBe(true);
 	});
 
-	it('two different sets are not equivalent', () => {
+	it('two sets with some shared elements are not equivalent', () => {
 		expect(equivalence(setA, setB)).toBe(false);
 	});
 
-	it('three different sets are not equivalent', () => {
+	it('three sets with some shared elements are not equivalent', () => {
 		expect(equivalence(setA, setB, setC)).toBe(false);
+	});
+
+	it('two sets with no shared elements are not equivalent', () => {
+		expect(equivalence(setD, setE)).toBe(false);
+	});
+
+	it('three sets with no shared elements are not equivalent', () => {
+		expect(equivalence(setD, setE, setF)).toBe(false);
 	});
 
 	it('many different sets are not equivalent', () => {

--- a/test/unit/comparisons/pairwise-disjoint.function.test.ts
+++ b/test/unit/comparisons/pairwise-disjoint.function.test.ts
@@ -38,6 +38,14 @@ function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {
 		expect(pairwiseDisjoint(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets with no shared elements are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setD, setE)).toBe(true);
+	});
+
+	it('three sets with no shared elements are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setD, setE, setF)).toBe(true);
+	});
+
 	it('many sets with some shared elements are not pairwise disjoint', () => {
 		expect(pairwiseDisjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/comparisons/proper-subset.function.test.ts
+++ b/test/unit/comparisons/proper-subset.function.test.ts
@@ -38,6 +38,14 @@ function properSubsetTests<T>(testSets: TestSets<T>): void {
 		expect(properSubset(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets no shared elements are not proper subsets', () => {
+		expect(properSubset(setD, setE)).toBe(false);
+	});
+
+	it('three sets with no shared elements are not proper subsets', () => {
+		expect(properSubset(setD, setE, setF)).toBe(false);
+	});
+
 	it('many sets with different elements are not proper subsets', () => {
 		expect(properSubset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/comparisons/proper-superset.function.test.ts
+++ b/test/unit/comparisons/proper-superset.function.test.ts
@@ -38,6 +38,14 @@ function properSupersetTests<T>(testSets: TestSets<T>): void {
 		expect(properSuperset(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets no shared elements are not proper supersets', () => {
+		expect(properSuperset(setD, setE)).toBe(false);
+	});
+
+	it('three sets with no shared elements are not proper supersets', () => {
+		expect(properSuperset(setD, setE, setF)).toBe(false);
+	});
+
 	it('many sets with different elements are not proper supersets', () => {
 		expect(properSuperset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/comparisons/subset.function.test.ts
+++ b/test/unit/comparisons/subset.function.test.ts
@@ -38,6 +38,14 @@ function subsetTests<T>(testSets: TestSets<T>): void {
 		expect(subset(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets with no shared elements are not subsets', () => {
+		expect(subset(setD, setE)).toBe(false);
+	});
+
+	it('three sets with no shared elements are not subsets', () => {
+		expect(subset(setD, setE, setF)).toBe(false);
+	});
+
 	it('many sets with different elements are not subsets', () => {
 		expect(subset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/comparisons/superset.function.test.ts
+++ b/test/unit/comparisons/superset.function.test.ts
@@ -38,6 +38,14 @@ function supersetTests<T>(testSets: TestSets<T>): void {
 		expect(superset(setA, setB, setC)).toBe(false);
 	});
 
+	it('two sets with no shared elements are not supersets', () => {
+		expect(superset(setD, setE)).toBe(false);
+	});
+
+	it('three sets with no shared elements are not supersets', () => {
+		expect(superset(setD, setE, setF)).toBe(false);
+	});
+
 	it('many sets with different elements are not supersets', () => {
 		expect(superset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});

--- a/test/unit/operations/difference.function.test.ts
+++ b/test/unit/operations/difference.function.test.ts
@@ -47,6 +47,16 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, differenceABC)).toBe(true);
 	});
 
+	it('two disjoint sets\' difference is the first set', () => {
+		const result = difference(setD, setE);
+		expect(equivalence(result, setD)).toBe(true);
+	});
+
+	it('three disjoint sets\' difference is the first set', () => {
+		const result = difference(setD, setE, setF);
+		expect(equivalence(result, setD)).toBe(true);
+	});
+
 	it('many sets\' difference is a subset of the first', () => {
 		const result = difference(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, differenceABC)).toBe(true);

--- a/test/unit/operations/intersection.function.test.ts
+++ b/test/unit/operations/intersection.function.test.ts
@@ -47,6 +47,16 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, intersectionABC)).toBe(true);
 	});
 
+	it('two disjoint sets\' intersection is the empty set', () => {
+		const result = intersection(setD, setE);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('three disjoint sets\' intersection is the empty set', () => {
+		const result = intersection(setD, setE, setF);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
 	it('many sets\' intersection is a subset of the first', () => {
 		const result = intersection(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, empty)).toBe(true);

--- a/test/unit/operations/union.function.test.ts
+++ b/test/unit/operations/union.function.test.ts
@@ -8,9 +8,11 @@ describe('union', () => {
 });
 
 function unionTests<T>(testSets: TestSets<T>): void {
-	const { a, b, c, d, e, empty, f, g, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { a, b, c, d, e, empty, f, g, h, i, j, setA, setB, setC, setD, setE, setF, universal } = testSets;
 	const unionAB = new Set<T>([ a, b, c, d, e, f ]);
 	const unionABC = new Set<T>([ a, b, c, d, e, f, g ]);
+	const unionDE = new Set<T>([ h, i ]);
+	const unionDEF = new Set<T>([ h, i, j ]);
 
 	it('no sets union returns empty set', () => {
 		const result = union();
@@ -45,6 +47,16 @@ function unionTests<T>(testSets: TestSets<T>): void {
 	it('three sets\' union contains all elements from all sets', () => {
 		const result = union(setA, setB, setC);
 		expect(equivalence(result, unionABC)).toBe(true);
+	});
+
+	it('two sets\' disjoint union contains all elements from both sets', () => {
+		const result = union(setD, setE);
+		expect(equivalence(result, unionDE)).toBe(true);
+	});
+
+	it('three sets\' disjoint union contains all elements from all sets', () => {
+		const result = union(setD, setE, setF);
+		expect(equivalence(result, unionDEF)).toBe(true);
 	});
 
 	it('many sets\' union contains all elements from all sets', () => {

--- a/test/unit/operations/xor.function.test.ts
+++ b/test/unit/operations/xor.function.test.ts
@@ -11,6 +11,8 @@ function xorTests<T>(testSets: TestSets<T>): void {
 	const { c, d, e, empty, f, g, h, i, j, setA, setB, setC, setD, setE, setF, universal } = testSets;
 	const xorAB = new Set<T>([ c, d, e, f ]);
 	const xorABC = new Set<T>([ e, f, g ]);
+	const xorDE = new Set<T>([ h, i ]);
+	const xorDEF = new Set<T>([ h, i, j ]);
 	const xorABCDEF = new Set<T>([ e, f, g, h, i, j ]);
 	const xorAU = new Set<T>([ d, f, g, h, i, j ]);
 
@@ -47,6 +49,16 @@ function xorTests<T>(testSets: TestSets<T>): void {
 	it('three different sets xor returns unique elements', () => {
 		const result = xor(setA, setB, setC);
 		expect(equivalence(result, xorABC)).toBe(true);
+	});
+
+	it('two disjoint sets xor returns all elements', () => {
+		const result = xor(setD, setE);
+		expect(equivalence(result, xorDE)).toBe(true);
+	});
+
+	it('three disjoint sets xor returns all elements', () => {
+		const result = xor(setD, setE, setF);
+		expect(equivalence(result, xorDEF)).toBe(true);
 	});
 
 	it('many different sets xor returns unique elements', () => {


### PR DESCRIPTION
### added disjoint sets unit tests:
Added two new tests to each of the `comparisons` and `operations` test suites:
- `two disjoint sets`: tests `function(setD, setE)`
- `three disjoint sets`: tests `function(setD, setE, setF)`