### PR TITLE
mark the package as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"dist"
 	],
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc",
 		"lint": "eslint src test",


### PR DESCRIPTION
### Description:
Webpack, as well as some other bundlers, use the `"sideEffects"` package field in order to tell whether a package can optimally utilize `tree shaking` in the bundling process.

This library contains individual utilities. And each of those should be tree shakable by bundlers. If you only want to serve `difference` out of this package, you should be able to do so.

### Resources:
- [the webpack guide to tree shaking](https://webpack.js.org/guides/tree-shaking)
- [what does webpack expect from a package with "sideEffects" false](https://stackoverflow.com/questions/49160752/what-does-webpack-4-expect-from-a-package-with-sideeffects-false)
- [a good conversation about whether or not to specify the "sideEffects" field](https://github.com/ai/nanoid/issues/108)