### PR TITLE
standardized the custom comparisons unit tests

### DIFF
--- a/test/unit/comparisons/disjoint.function.test.ts
+++ b/test/unit/comparisons/disjoint.function.test.ts
@@ -46,12 +46,24 @@ function disjointTests<T>(testSets: TestSets<T>): void {
 		expect(disjoint(setD, setE, setF)).toBe(true);
 	});
 
+	it('disjoint sets with decreasing cardinality are disjoint', () => {
+		expect(disjoint(setA, setD)).toBe(true);
+	});
+
+	it('disjoint sets with increasing cardinality are disjoint', () => {
+		expect(disjoint(setD, setA)).toBe(true);
+	});
+
 	it('many sets with some shared elements of the first are not disjoint', () => {
 		expect(disjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with no shared elements of the first are disjoint', () => {
 		expect(disjoint(setF, setE, setD, setC, setB, setA)).toBe(true);
+	});
+
+	it('the empty set is disjoint with itself', () => {
+		expect(disjoint(empty, empty)).toBe(true);
 	});
 
 	it('any non-empty set and the empty set are disjoint', () => {
@@ -70,21 +82,11 @@ function disjointTests<T>(testSets: TestSets<T>): void {
 		expect(disjoint(universal, setA)).toBe(false);
 	});
 
-	it('the empty set is disjoint with itself', () => {
-		expect(disjoint(empty, empty)).toBe(true);
+	it('the empty set is disjoint from every non-empty set', () => {
+		expect(disjoint(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(true);
 	});
 
-	/* custom disjoint tests */
-
-	it('two sets with no shared elements are disjoint', () => {
-		expect(disjoint(setA, setD)).toBe(true);
-	});
-
-	it('many sets with no shared elements are disjoint', () => {
-		expect(disjoint(setA, setD, setE, setF)).toBe(true);
-	});
-
-	it('a set & many of another set with no shared elements are disjoint', () => {
-		expect(disjoint(setA, setD, setD, setD)).toBe(true);
+	it('the universal set is not disjoint from every non-universal set', () => {
+		expect(disjoint(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(false);
 	});
 }

--- a/test/unit/comparisons/equivalence.function.test.ts
+++ b/test/unit/comparisons/equivalence.function.test.ts
@@ -8,7 +8,7 @@ describe('equivalence', () => {
 });
 
 function equivalenceTests<T>(testSets: TestSets<T>): void {
-	const { empty, minimal, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { empty, setA, setB, setC, setD, setE, setF, universal } = testSets;
 
 	it('no sets are equivalent', () => {
 		expect(equivalence()).toBe(true);
@@ -46,12 +46,24 @@ function equivalenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(setD, setE, setF)).toBe(false);
 	});
 
+	it('disjoint sets with decreasing cardinality are not equivalent', () => {
+		expect(equivalence(setA, setD)).toBe(false);
+	});
+
+	it('disjoint sets with increasing cardinality are not equivalent', () => {
+		expect(equivalence(setD, setA)).toBe(false);
+	});
+
 	it('many different sets are not equivalent', () => {
 		expect(equivalence(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many different sets (reversed) are not equivalent', () => {
 		expect(equivalence(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is equivalent to itself', () => {
+		expect(equivalence(empty, empty)).toBe(true);
 	});
 
 	it('any non-empty set and the empty set are not equivalent', () => {
@@ -70,13 +82,11 @@ function equivalenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(universal, setA)).toBe(false);
 	});
 
-	it('the empty set is equivalent to itself', () => {
-		expect(equivalence(empty, empty)).toBe(true);
+	it('the empty set is not equivalent to every non-empty set', () => {
+		expect(equivalence(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(false);
 	});
 
-	/* custom equivalence tests */
-
-	it('two sets with different cardinalities are not equivalent', () => {
-		expect(equivalence(setA, minimal)).toBe(false);
+	it('the universal set is not equivalent to every non-universal set', () => {
+		expect(equivalence(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(false);
 	});
 }

--- a/test/unit/comparisons/pairwise-disjoint.function.test.ts
+++ b/test/unit/comparisons/pairwise-disjoint.function.test.ts
@@ -46,12 +46,24 @@ function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {
 		expect(pairwiseDisjoint(setD, setE, setF)).toBe(true);
 	});
 
+	it('disjoint sets with decreasing cardinality are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setA, setD)).toBe(true);
+	});
+
+	it('disjoint sets with increasing cardinality are pairwise disjoint', () => {
+		expect(pairwiseDisjoint(setD, setA)).toBe(true);
+	});
+
 	it('many sets with some shared elements are not pairwise disjoint', () => {
 		expect(pairwiseDisjoint(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with some shared elements are not pairwise disjoint', () => {
 		expect(pairwiseDisjoint(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is pairwise disjoint with itself', () => {
+		expect(pairwiseDisjoint(empty, empty)).toBe(true);
 	});
 
 	it('any non-empty set and the empty set are pairwise disjoint', () => {
@@ -70,21 +82,11 @@ function pairwiseDisjointTests<T>(testSets: TestSets<T>): void {
 		expect(pairwiseDisjoint(universal, setA)).toBe(false);
 	});
 
-	it('the empty set is pairwise disjoint with itself', () => {
-		expect(pairwiseDisjoint(empty, empty)).toBe(true);
+	it('the empty set is not pairwise disjoint to every non-empty set and the universal set', () => {
+		expect(pairwiseDisjoint(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(false);
 	});
 
-	/* custom pairwise disjoint tests */
-
-	it('two sets with no shared elements are pairwise disjoint', () => {
-		expect(pairwiseDisjoint(setA, setD)).toBe(true);
-	});
-
-	it('many sets with no shared elements are pairwise disjoint', () => {
-		expect(pairwiseDisjoint(setA, setD, setE, setF)).toBe(true);
-	});
-
-	it('a set & many of another set with no shared elements are not pairwise disjoint', () => {
-		expect(pairwiseDisjoint(setA, setD, setD, setD)).toBe(false);
+	it('the universal set is not pairwise disjoint to every non-universal set', () => {
+		expect(pairwiseDisjoint(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(false);
 	});
 }

--- a/test/unit/comparisons/proper-subset.function.test.ts
+++ b/test/unit/comparisons/proper-subset.function.test.ts
@@ -8,7 +8,7 @@ describe('proper subset', () => {
 });
 
 function properSubsetTests<T>(testSets: TestSets<T>): void {
-	const { empty, minimal, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { empty, setA, setB, setC, setD, setE, setF, universal } = testSets;
 
 	it('no sets are proper subsets', () => {
 		expect(properSubset()).toBe(true);
@@ -46,12 +46,24 @@ function properSubsetTests<T>(testSets: TestSets<T>): void {
 		expect(properSubset(setD, setE, setF)).toBe(false);
 	});
 
+	it('disjoint sets with decreasing cardinality are not proper subsets', () => {
+		expect(properSubset(setA, setD)).toBe(false);
+	});
+
+	it('disjoint sets with increasing cardinality are not proper subsets', () => {
+		expect(properSubset(setD, setA)).toBe(false);
+	});
+
 	it('many sets with different elements are not proper subsets', () => {
 		expect(properSubset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with different elements are not proper subsets', () => {
 		expect(properSubset(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is not a proper subset of itself', () => {
+		expect(properSubset(empty, empty)).toBe(false);
 	});
 
 	it('any non-empty set is not a proper subset of the empty set', () => {
@@ -70,21 +82,11 @@ function properSubsetTests<T>(testSets: TestSets<T>): void {
 		expect(properSubset(universal, setA)).toBe(false);
 	});
 
-	it('the empty set is not a proper subset of itself', () => {
-		expect(properSubset(empty, empty)).toBe(false);
-	});
-
-	/* custom proper subset tests */
-
-	it('following sets with lower cardinalities are not proper subsets', () => {
-		expect(properSubset(setA, minimal)).toBe(false);
-	});
-
-	it('sets without element bijection are not proper subsets', () => {
-		expect(properSubset(setD, setA)).toBe(false);
-	});
-
 	it('the empty set is a proper subset of every non-empty set', () => {
-		expect(properSubset(empty, minimal, setA, setB, setC, universal)).toBe(true);
+		expect(properSubset(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(true);
+	});
+
+	it('the universal set is not a proper subset of every non-universal set', () => {
+		expect(properSubset(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(false);
 	});
 }

--- a/test/unit/comparisons/proper-superset.function.test.ts
+++ b/test/unit/comparisons/proper-superset.function.test.ts
@@ -8,7 +8,7 @@ describe('proper superset', () => {
 });
 
 function properSupersetTests<T>(testSets: TestSets<T>): void {
-	const { empty, minimal, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { empty, setA, setB, setC, setD, setE, setF, universal } = testSets;
 
 	it('no sets are proper supersets', () => {
 		expect(properSuperset()).toBe(true);
@@ -46,12 +46,24 @@ function properSupersetTests<T>(testSets: TestSets<T>): void {
 		expect(properSuperset(setD, setE, setF)).toBe(false);
 	});
 
+	it('disjoint sets with decreasing cardinality are not proper supersets', () => {
+		expect(properSuperset(setA, setD)).toBe(false);
+	});
+
+	it('disjoint sets with increasing cardinality are not proper supersets', () => {
+		expect(properSuperset(setD, setA)).toBe(false);
+	});
+
 	it('many sets with different elements are not proper supersets', () => {
 		expect(properSuperset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with different elements are not proper supersets', () => {
 		expect(properSuperset(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is not a proper superset of itself', () => {
+		expect(properSuperset(empty, empty)).toBe(false);
 	});
 
 	it('any non-empty set is a proper superset of the empty set', () => {
@@ -70,21 +82,11 @@ function properSupersetTests<T>(testSets: TestSets<T>): void {
 		expect(properSuperset(universal, setA)).toBe(true);
 	});
 
-	it('the empty set is not a proper superset of itself', () => {
-		expect(properSuperset(empty, empty)).toBe(false);
-	});
-
-	/* custom proper superset tests */
-
-	it('following sets with greater cardinalities are not proper supersets', () => {
-		expect(properSuperset(minimal, setA)).toBe(false);
-	});
-
-	it('sets without element bijection are not proper supersets', () => {
-		expect(properSuperset(setA, setD)).toBe(false);
+	it('the empty set is not a proper superset of every non-empty set', () => {
+		expect(properSuperset(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(false);
 	});
 
 	it('the universal set is a proper superset of every non-universal set', () => {
-		expect(properSuperset(universal, setA, setB, setC, minimal, empty)).toBe(true);
+		expect(properSuperset(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(true);
 	});
 }

--- a/test/unit/comparisons/subset.function.test.ts
+++ b/test/unit/comparisons/subset.function.test.ts
@@ -8,7 +8,7 @@ describe('subset', () => {
 });
 
 function subsetTests<T>(testSets: TestSets<T>): void {
-	const { empty, minimal, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { empty, setA, setB, setC, setD, setE, setF, universal } = testSets;
 
 	it('no sets are subsets', () => {
 		expect(subset()).toBe(true);
@@ -46,12 +46,24 @@ function subsetTests<T>(testSets: TestSets<T>): void {
 		expect(subset(setD, setE, setF)).toBe(false);
 	});
 
+	it('disjoint sets with decreasing cardinality are not subsets', () => {
+		expect(subset(setA, setD)).toBe(false);
+	});
+
+	it('disjoint sets with increasing cardinality are not subsets', () => {
+		expect(subset(setD, setA)).toBe(false);
+	});
+
 	it('many sets with different elements are not subsets', () => {
 		expect(subset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with different elements are not subsets', () => {
 		expect(subset(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is a subset of itself', () => {
+		expect(subset(empty, empty)).toBe(true);
 	});
 
 	it('any non-empty set is not a subset of the empty set', () => {
@@ -70,21 +82,11 @@ function subsetTests<T>(testSets: TestSets<T>): void {
 		expect(subset(universal, setA)).toBe(false);
 	});
 
-	it('the empty set is a subset of itself', () => {
-		expect(subset(empty, empty)).toBe(true);
+	it('the empty set is a subset of every non-empty set', () => {
+		expect(subset(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(true);
 	});
 
-	/* custom subset tests */
-
-	it('following sets with lower cardinalities are not subsets', () => {
-		expect(subset(setA, minimal)).toBe(false);
-	});
-
-	it('sets without element bijection are not subsets', () => {
-		expect(subset(setD, setA)).toBe(false);
-	});
-
-	it('the empty set is a subset of every set', () => {
-		expect(subset(empty, minimal, setA, setB, setC, universal)).toBe(true);
+	it('the universal set is not a subset of every non-universal set', () => {
+		expect(subset(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(false);
 	});
 }

--- a/test/unit/comparisons/superset.function.test.ts
+++ b/test/unit/comparisons/superset.function.test.ts
@@ -8,7 +8,7 @@ describe('superset', () => {
 });
 
 function supersetTests<T>(testSets: TestSets<T>): void {
-	const { empty, minimal, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { empty, setA, setB, setC, setD, setE, setF, universal } = testSets;
 
 	it('no sets are superset', () => {
 		expect(superset()).toBe(true);
@@ -46,12 +46,24 @@ function supersetTests<T>(testSets: TestSets<T>): void {
 		expect(superset(setD, setE, setF)).toBe(false);
 	});
 
+	it('disjoint sets with decreasing cardinality are not supersets', () => {
+		expect(superset(setA, setD)).toBe(false);
+	});
+
+	it('disjoint sets with increasing cardinality are not supersets', () => {
+		expect(superset(setD, setA)).toBe(false);
+	});
+
 	it('many sets with different elements are not supersets', () => {
 		expect(superset(setA, setB, setC, setD, setE, setF)).toBe(false);
 	});
 
 	it('many sets (reversed) with different elements are not supersets', () => {
 		expect(superset(setF, setE, setD, setC, setB, setA)).toBe(false);
+	});
+
+	it('the empty set is a superset of itself', () => {
+		expect(superset(empty, empty)).toBe(true);
 	});
 
 	it('any non-empty set is a superset of the empty set', () => {
@@ -70,21 +82,11 @@ function supersetTests<T>(testSets: TestSets<T>): void {
 		expect(superset(universal, setA)).toBe(true);
 	});
 
-	it('the empty set is a superset of itself', () => {
-		expect(superset(empty, empty)).toBe(true);
+	it('the empty set is not a superset of every non-empty set', () => {
+		expect(superset(empty, setA, setB, setC, setD, setE, setF, universal)).toBe(false);
 	});
 
-	/* custom superset tests */
-
-	it('following sets with greater cardinalities are not supersets', () => {
-		expect(superset(minimal, setA)).toBe(false);
-	});
-
-	it('sets without element bijection are not supersets', () => {
-		expect(superset(setA, setD)).toBe(false);
-	});
-
-	it('the universal set is a superset of every set', () => {
-		expect(superset(universal, setA, setB, setC, minimal, empty)).toBe(true);
+	it('the universal set is a superset of every non-universal set', () => {
+		expect(superset(universal, setF, setE, setD, setC, setB, setA, empty)).toBe(true);
 	});
 }

--- a/test/unit/operations/difference.function.test.ts
+++ b/test/unit/operations/difference.function.test.ts
@@ -58,6 +58,16 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, setD)).toBe(true);
 	});
 
+	it('the difference of disjoint sets with decreasing cardinality is the first set', () => {
+		const result = difference(setA, setD);
+		expect(equivalence(result, setA)).toBe(true);
+	});
+
+	it('the difference of disjoint sets with increasing cardinality is the first set', () => {
+		const result = difference(setD, setA);
+		expect(equivalence(result, setD)).toBe(true);
+	});
+
 	it('many sets\' difference is a subset of the first', () => {
 		const result = difference(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, differenceABC)).toBe(true);
@@ -66,6 +76,11 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 	it('many sets\' (reversed) difference is a subset of the first', () => {
 		const result = difference(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, setF)).toBe(true);
+	});
+
+	it('the empty set\'s difference with itself is itself', () => {
+		const result = difference(empty, empty);
+		expect(equivalence(result, empty)).toBe(true);
 	});
 
 	it('any non-empty set\'s difference with the empty set is itself', () => {
@@ -88,8 +103,13 @@ function differenceTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, differenceUA)).toBe(true);
 	});
 
-	it('the empty set\'s difference with itself is itself', () => {
-		const result = difference(empty, empty);
+	it('the empty set\'s difference with all non-empty sets is the empty set', () => {
+		const result = difference(empty, setA, setB, setC, setD, setE, setF, universal);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('the universal set\'s difference with all non-universal sets is the empty set', () => {
+		const result = difference(universal, setF, setE, setD, setC, setB, setA, empty);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 }

--- a/test/unit/operations/intersection.function.test.ts
+++ b/test/unit/operations/intersection.function.test.ts
@@ -57,6 +57,16 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
+	it('the intersection of disjoint sets with decreasing cardinality is the empty set', () => {
+		const result = intersection(setA, setD);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('the intersection of disjoint sets with increasing cardinality is the empty set', () => {
+		const result = intersection(setD, setA);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
 	it('many sets\' intersection is a subset of the first', () => {
 		const result = intersection(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, empty)).toBe(true);
@@ -64,6 +74,11 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 
 	it('many sets\' (reversed) intersection is a subset of the first', () => {
 		const result = intersection(setF, setE, setD, setC, setB, setA);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('the empty set\'s intersection with itself is itself', () => {
+		const result = intersection(empty, empty);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 
@@ -87,8 +102,13 @@ function intersectionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, setA)).toBe(true);
 	});
 
-	it('the empty set\'s intersection with itself is itself', () => {
-		const result = intersection(empty, empty);
+	it('the empty set\'s intersection with all non-empty sets is the empty set', () => {
+		const result = intersection(empty, setA, setB, setC, setD, setE, setF, universal);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('the universal set\'s intersection with all non-universal sets is the empty set', () => {
+		const result = intersection(universal, setF, setE, setD, setC, setB, setA, empty);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 }

--- a/test/unit/operations/union.function.test.ts
+++ b/test/unit/operations/union.function.test.ts
@@ -13,6 +13,7 @@ function unionTests<T>(testSets: TestSets<T>): void {
 	const unionABC = new Set<T>([ a, b, c, d, e, f, g ]);
 	const unionDE = new Set<T>([ h, i ]);
 	const unionDEF = new Set<T>([ h, i, j ]);
+	const unionAD = new Set<T>([ a, b, c, e, h ]);
 
 	it('no sets union returns empty set', () => {
 		const result = union();
@@ -59,6 +60,16 @@ function unionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, unionDEF)).toBe(true);
 	});
 
+	it('the union of disjoint sets with decreasing cardinality contains all elements from both sets', () => {
+		const result = union(setA, setD);
+		expect(equivalence(result, unionAD)).toBe(true);
+	});
+
+	it('the union of disjoint sets with increasing cardinality contains all elements from both sets', () => {
+		const result = union(setD, setA);
+		expect(equivalence(result, unionAD)).toBe(true);
+	});
+
 	it('many sets\' union contains all elements from all sets', () => {
 		const result = union(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, universal)).toBe(true);
@@ -67,6 +78,11 @@ function unionTests<T>(testSets: TestSets<T>): void {
 	it('many sets\' (reversed) union contains all elements from all sets', () => {
 		const result = union(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, universal)).toBe(true);
+	});
+
+	it('the empty set\'s union with itself is itself', () => {
+		const result = union(empty, empty);
+		expect(equivalence(result, empty)).toBe(true);
 	});
 
 	it('any non-empty set\'s union with the empty set is itself', () => {
@@ -89,8 +105,13 @@ function unionTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, universal)).toBe(true);
 	});
 
-	it('the empty set\'s union with itself is itself', () => {
-		const result = union(empty, empty);
-		expect(equivalence(result, empty)).toBe(true);
+	it('the empty set\'s union with all non-empty sets is the universal set', () => {
+		const result = union(empty, setA, setB, setC, setD, setE, setF, universal);
+		expect(equivalence(result, universal)).toBe(true);
+	});
+
+	it('the universal set\'s union with all non-universal sets is the universal set', () => {
+		const result = union(universal, setF, setE, setD, setC, setB, setA, empty);
+		expect(equivalence(result, universal)).toBe(true);
 	});
 }

--- a/test/unit/operations/xor.function.test.ts
+++ b/test/unit/operations/xor.function.test.ts
@@ -8,11 +8,12 @@ describe('xor', () => {
 });
 
 function xorTests<T>(testSets: TestSets<T>): void {
-	const { c, d, e, empty, f, g, h, i, j, setA, setB, setC, setD, setE, setF, universal } = testSets;
+	const { a, b, c, d, e, empty, f, g, h, i, j, setA, setB, setC, setD, setE, setF, universal } = testSets;
 	const xorAB = new Set<T>([ c, d, e, f ]);
 	const xorABC = new Set<T>([ e, f, g ]);
 	const xorDE = new Set<T>([ h, i ]);
 	const xorDEF = new Set<T>([ h, i, j ]);
+	const xorAD = new Set<T>([ a, b, c, e, h ]);
 	const xorABCDEF = new Set<T>([ e, f, g, h, i, j ]);
 	const xorAU = new Set<T>([ d, f, g, h, i, j ]);
 
@@ -61,6 +62,16 @@ function xorTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, xorDEF)).toBe(true);
 	});
 
+	it('the xor of disjoint sets with decreasing cardinality contains all elements from both sets', () => {
+		const result = xor(setA, setD);
+		expect(equivalence(result, xorAD)).toBe(true);
+	});
+
+	it('the xor of disjoint sets with increasing cardinality contains all elements from both sets', () => {
+		const result = xor(setD, setA);
+		expect(equivalence(result, xorAD)).toBe(true);
+	});
+
 	it('many different sets xor returns unique elements', () => {
 		const result = xor(setA, setB, setC, setD, setE, setF);
 		expect(equivalence(result, xorABCDEF)).toBe(true);
@@ -69,6 +80,11 @@ function xorTests<T>(testSets: TestSets<T>): void {
 	it('many different sets (reversed) xor returns unique elements', () => {
 		const result = xor(setF, setE, setD, setC, setB, setA);
 		expect(equivalence(result, xorABCDEF)).toBe(true);
+	});
+
+	it('the empty set\'s xor with itself is itself', () => {
+		const result = xor(empty, empty);
+		expect(equivalence(result, empty)).toBe(true);
 	});
 
 	it('any non-empty set\'s xor with the empty set is itself', () => {
@@ -91,8 +107,13 @@ function xorTests<T>(testSets: TestSets<T>): void {
 		expect(equivalence(result, xorAU)).toBe(true);
 	});
 
-	it('the empty set\'s xor with itself is itself', () => {
-		const result = xor(empty, empty);
+	it('the empty set\'s xor with all non-empty sets and the universal set is the empty set', () => {
+		const result = xor(empty, setA, setB, setC, setD, setE, setF, universal);
+		expect(equivalence(result, empty)).toBe(true);
+	});
+
+	it('the universal set\'s union with all non-universal sets is the empty set', () => {
+		const result = xor(universal, setF, setE, setD, setC, setB, setA, empty);
 		expect(equivalence(result, empty)).toBe(true);
 	});
 }

--- a/test/util/test-sets/test-sets.model.ts
+++ b/test/util/test-sets/test-sets.model.ts
@@ -18,8 +18,6 @@ export abstract class TestSets<T> {
 	/* the universal set: U, contains: a, b, c, d, e, f, g, h, i, j */
 	public readonly universal: ReadonlySet<T>;
 
-	/* contains: a */
-	public readonly minimal: ReadonlySet<T>;
 	/* contains: a, b, c, e */
 	public readonly setA: ReadonlySet<T>;
 	/* contains: a, b, d, f */
@@ -63,7 +61,6 @@ export abstract class TestSets<T> {
 		this.empty = new Set<never>();
 		this.universal = new Set<T>([ a, b, c, d, e, f, g, h, i, j ]);
 
-		this.minimal = new Set<T>([ a ]);
 		this.setA = new Set<T>([ a, b, c, e ]);
 		this.setB = new Set<T>([ a, b, d, f ]);
 		this.setC = new Set<T>([ a, c, d, g ]);


### PR DESCRIPTION
### standardized the custom comparisons unit tests:

Formerly, each of the `comparisons` unit test suites had custom implemented tests at the end of their files. And some of those tests have since become unnecessary due to other standardized test additions. Of those custom tests, there were four that could reasonably be standardized across all of the `comparisons` and `operations` unit tests, such that all tests maintained full code coverage.

Added four new tests to each of the `comparisons` and `operations` test suites:
1. `2 disjoint sets with decreasing cardinality`: tests `function(setA, setD)`.
2. `2 disjoint sets with increasing cardinality`: tests `function(setD, setA)`.
3. `empty, all sets, & universal`: tests `function(∅, setA, setB, setC, setD, setE, setF, U)`.
4. `universal, all sets, & empty`: tests `function(U, setF, setE, setD, setC, setB, setA, ∅)`.