### PR TITLE
improved xor performance

### DIFF
--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -11,16 +11,53 @@ export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  * @description A ∆ B ≔ { x : (x ∈ A) ⊕ (x ∈ B) }
  */
 export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
-	const resultSet = new Set<T>(sets.shift());
-	const reusedElements = new Set<T>();
+	if (sets.length < 2) {
+		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+	}
 
-	for (const set of sets) {
-		for (const element of set) {
-			if (resultSet.has(element)) {
-				resultSet.delete(element);
-				reusedElements.add(element);
-			} else if (!reusedElements.has(element)) {
-				resultSet.add(element);
+	const resultSet = new Set<T>();
+	const duplicates = new Set<T>();
+	const primarySet = sets.shift()!;
+	const secondarySet = sets.shift()!;
+
+	primaryLoop(primarySet, secondarySet);
+	primaryLoop(secondarySet, primarySet);
+	function primaryLoop(primary: S, secondary: S): void {
+		if (sets.length !== 0) {
+			for (const element of primary) {
+				if (!secondary.has(element)) {
+					resultSet.add(element);
+				} else {
+					duplicates.add(element);
+				}
+			}
+		} else {
+			for (const element of primary) {
+				if (!secondary.has(element)) {
+					resultSet.add(element);
+				}
+			}
+		}
+	}
+
+	sets.forEach(tertiaryLoop);
+	function tertiaryLoop(set: S, index: number): void {
+		if (index < sets.length - 1) {
+			for (const element of set) {
+				if (resultSet.has(element)) {
+					resultSet.delete(element);
+					duplicates.add(element);
+				} else if (!duplicates.has(element)) {
+					resultSet.add(element);
+				}
+			}
+		} else {
+			for (const element of set) {
+				if (resultSet.has(element)) {
+					resultSet.delete(element);
+				} else if (!duplicates.has(element)) {
+					resultSet.add(element);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### improved `xor` performance:

Added a preface to `xor`, which compares elements in the first 2 sets to create the initial `resultSet`, and the initial `duplicates`. Additionally, split implementations of each loop into 2 branches, one which adds elements to `duplicates` and one which does not. 

This implementation saves significant time at scale by not adding elements to the `duplicates` set on the final set comparison. Indeed, for the `xor` of only 2 sets: no elements whatsoever are added to `duplicates`. And there is no time wasted adding elements to the `resultSet` which are immediately removed, on the first comparison. 

The scale tests show that when taking the `xor` of 2 sets, we see a performance improvement of anywhere from ~30 to ~70%. And for 3 or more sets, we still see improvements of ~10 to ~30%.

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[original] raw data:</h4></summary>

|              | xor(of1)        | xor(of1, of1)    | xor(of1, of2)   | xor(of2, of1)   | xor(of1, of1, of1) | xor(of1, of2, of3) | xor(of3, of2, of1) |
|:-------------|:----------------|:-----------------|:----------------|:----------------|:-------------------|:-------------------|:-------------------|
| test 1:      | 4,289.291ms     | 12,265.707ms     | 6,822.403ms     | 8,812.099ms     | 13,489.179ms       | 9,289.335ms        | 10,066.066ms       |
| test 2:      | 5,002.647ms     | 13,373.451ms     | 7,521.562ms     | 8,966.832ms     | 14,557.072ms       | 9,911.047ms        | 10,953.452ms       |
| test 3:      | 4,708.450ms     | 12,850.578ms     | 7,378.796ms     | 8,919.654ms     | 13,818.081ms       | 9,836.513ms        | 11,157.035ms       |
| test 4:      | 4,123.982ms     | 12,572.005ms     | 7,701.330ms     | 8,939.424ms     | 13,487.043ms       | 8,767.213ms        | 10,390.920ms       |
| test 5:      | 4,922.881ms     | 16,788.944ms     | 7,327.372ms     | 9,940.865ms     | 14,577.289ms       | 9,589.192ms        | 11,942.640ms       |
|              |
| **average:** | **4,609.450ms** | **13,570.137ms** | **7,350.293ms** | **9,115.775ms** | **13,985.733ms**   | **9,478.660ms**    | **10,902.023ms**   |

|              | xor(100 Eq)   | xor(10k Eq)   | xor(100 Dj)     | xor(10k Dj)     |
|:-------------|:--------------|:--------------|:----------------|:----------------|
| test 1:      | 523.303ms     | 369.874ms     | 3,031.034ms     | 3,223.919ms     |
| test 2:      | 589.087ms     | 399.620ms     | 3,334.634ms     | 3,409.872ms     |
| test 3:      | 687.281ms     | 432.568ms     | 3,224.346ms     | 3,262.135ms     |
| test 4:      | 557.071ms     | 417.389ms     | 2,984.109ms     | 3,076.535ms     |
| test 5:      | 632.142ms     | 503.307ms     | 3,337.861ms     | 3,411.966ms     |
|              |
| **average:** | **597.777ms** | **424.552ms** | **3,182.397ms** | **3,276.885ms** |

|              | 100k ⋅ xor(2 Eq) | 100k ⋅ xor(5 Eq) | 100k ⋅ xor(2 Dj) | 100k ⋅ xor(5 Dj) |
|:-------------|:-----------------|:-----------------|:-----------------|:-----------------|
| test 1:      | 836.240ms        | 557.291ms        | 1,054.668ms      | 919.818ms        |
| test 2:      | 784.405ms        | 662.988ms        | 1,136.804ms      | 958.899ms        |
| test 3:      | 788.272ms        | 568.934ms        | 992.142ms        | 961.228ms        |
| test 4:      | 753.647ms        | 534.395ms        | 1,010.893ms      | 851.651ms        |
| test 5:      | 791.815ms        | 620.453ms        | 1,332.216ms      | 1,213.450ms      |
|              |
| **average:** | **790.876ms**    | **588.812ms**    | **1,105.345ms**  | **981.009ms**    |
</details>

<details>
<summary><h4 style="display: inline; margin-bottom: 0;">[refactor] raw data:</h4></summary>

|              | xor(of1)        | xor(of1, of1)   | xor(of1, of2)   | xor(of2, of1)   | xor(of1, of1, of1) | xor(of1, of2, of3) | xor(of3, of2, of1) |
|:-------------|:----------------|:----------------|:----------------|:----------------|:-------------------|:-------------------|:-------------------|
| test 1:      | 4,042.787ms     | 3,772.797ms     | 4,686.519ms     | 4,612.897ms     | 11,134.199ms       | 8,434.715ms        | 8,568.729ms        |
| test 2:      | 4,093.107ms     | 3,722.795ms     | 4,815.067ms     | 4,335.210ms     | 11,219.319ms       | 8,754.869ms        | 8,344.972ms        |
| test 3:      | 4,286.660ms     | 3,693.109ms     | 4,814.299ms     | 4,244.118ms     | 11,156.637ms       | 8,437.587ms        | 8,529.338ms        |
| test 4:      | 4,176.574ms     | 3,672.280ms     | 5,093.960ms     | 4,268.555ms     | 11,353.890ms       | 8,516.703ms        | 8,480.596ms        |
| test 5:      | 4,249.337ms     | 3,680.425ms     | 4,860.920ms     | 4,282.032ms     | 11,388.819ms       | 8,571.650ms        | 8,595.393ms        |
|              |
| **average:** | **4,169.693ms** | **3,708.281ms** | **4,854.153ms** | **4,348.562ms** | **11,250.573ms**   | **8,543.105ms**    | **8,503.806ms**    |

|              | xor(100 Eq)   | xor(10k Eq)   | xor(100 Dj)     | xor(10k Dj)     |
|:-------------|:--------------|:--------------|:----------------|:----------------|
| test 1:      | 533.265ms     | 311.343ms     | 3,078.072ms     | 3,032.642ms     |
| test 2:      | 490.466ms     | 315.553ms     | 3,094.432ms     | 3,161.461ms     |
| test 3:      | 487.250ms     | 302.945ms     | 3,034.009ms     | 3,148.477ms     |
| test 4:      | 490.392ms     | 313.950ms     | 3,077.279ms     | 3,214.733ms     |
| test 5:      | 493.380ms     | 304.258ms     | 3,150.739ms     | 3,106.725ms     |
|              |
| **average:** | **498.951ms** | **309.610ms** | **3,086.906ms** | **3,132.808ms** |

|              | 100k ⋅ xor(2 Eq) | 100k ⋅ xor(5 Eq) | 100k ⋅ xor(2 Dj) | 100k ⋅ xor(5 Dj) |
|:-------------|:-----------------|:-----------------|:-----------------|:-----------------|
| test 1:      | 533.170ms        | 442.016ms        | 693.439ms        | 845.515ms        |
| test 2:      | 261.622ms        | 494.277ms        | 743.395ms        | 972.946ms        |
| test 3:      | 562.718ms        | 431.362ms        | 696.113ms        | 860.681ms        |
| test 4:      | 297.686ms        | 437.088ms        | 784.171ms        | 973.658ms        |
| test 5:      | 554.094ms        | 439.272ms        | 742.306ms        | 857.492ms        |
|              |
| **average:** | **441.858ms**    | **448.803ms**    | **731.885ms**    | **902.058ms**    |
</details>

<details open>
<summary><h4 style="display: inline; margin-bottom: 0;">[performance improvement] raw data:</h4></summary>

|                  | xor(of1)    | xor(of1, of1) | xor(of1, of2) | xor(of2, of1) | xor(of1, of1, of1) | xor(of1, of2, of3) | xor(of3, of2, of1) |
|:-----------------|:------------|:--------------|:--------------|:--------------|:-------------------|:-------------------|:-------------------|
| original:        | 4,609.450ms | 13,570.137ms  | 7,350.293ms   | 9,115.775ms   | 13,985.733ms       | 9,478.660ms        | 10,902.023ms       |
| rewrite:         | 4,169.693ms | 3,708.281ms   | 4,854.153ms   | 4,348.562ms   | 11,250.573ms       | 8,543.105ms        | 8,503.806ms        |
|                  |
| **improvement:** | **+9.540%** | **+72.673%**  | **+33.960%**  | **+52.296%**  | **+19.557%**       | **+9.870%**        | **+21.998%**       |

|                  | xor(100 Eq)  | xor(10k Eq) | xor(100 Dj)  | xor(10k Dj) |
|:-----------------|:-------------|:------------|:-------------|:------------|
| original:        | 597.777ms    | 424.552ms   | 3,182.397ms  | 3,276.885ms |
| rewrite:         | 498.951ms    | 309.610ms   | 3,086.906ms  | 3,132.808ms |
|                  |
| **improvement:** | **+16.532%** | **+4.932%** | **+27.074%** | **+4.397%** |

|                  | 100k ⋅ xor(2 Eq) | 100k ⋅ xor(5 Eq) | 100k ⋅ xor(2 Dj) | 100k ⋅ xor(5 Dj) |
|:-----------------|:-----------------|:-----------------|:-----------------|:-----------------|
| original:        | 790.876ms        | 588.812ms        | 1,105.345ms      | 981.009ms        |
| rewrite:         | 441.858ms        | 448.803ms        | 731.885ms        | 902.058ms        |
|                  |
| **improvement:** | **+44.131%**     | **+23.778%**     | **+33.787%**     | **+8.048%**      |
</details>
