### PR TITLE
added large disjoint scale tests

### DIFF
--- a/test/scale/comparisons/disjoint.function.scale.test.ts
+++ b/test/scale/comparisons/disjoint.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('disjoint @ scale', () => {
-	describe('disjoint ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('disjoint ⋅ 2 large sets', () => {
+		const {multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('disjoint(of1):'.padEnd(padding), () => {
 			const result = Timer.time('disjoint', () => disjoint(multiplesOf1));
@@ -28,6 +28,16 @@ describe('disjoint @ scale', () => {
 			expect(result).toBe(false);
 		});
 
+		it('disjoint(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('disjoint', () => disjoint(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('disjoint ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('disjoint'));
+
 		it('disjoint(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('disjoint', () => disjoint(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(false);
@@ -41,6 +51,11 @@ describe('disjoint @ scale', () => {
 		it('disjoint(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('disjoint', () => disjoint(multiplesOf3, multiplesOf2, multiplesOf1));
 			expect(result).toBe(false);
+		});
+
+		it('disjoint(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('disjoint', () => disjoint(multiplesOf3, multiplesOf3B, multiplesOf3C));
+			expect(result).toBe(true);
 		});
 	});
 

--- a/test/scale/comparisons/equivalence.function.scale.test.ts
+++ b/test/scale/comparisons/equivalence.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('equivalence @ scale', () => {
-	describe('equivalence ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('equivalence ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('equivalence(of1):'.padEnd(padding), () => {
 			const result = Timer.time('equivalence', () => equivalence(multiplesOf1));
@@ -28,6 +28,16 @@ describe('equivalence @ scale', () => {
 			expect(result).toBe(false);
 		});
 
+		it('equivalence(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('equivalence', () => equivalence(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('equivalence ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('equivalence'));
+
 		it('equivalence(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('equivalence', () => equivalence(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(true);
@@ -40,6 +50,11 @@ describe('equivalence @ scale', () => {
 
 		it('equivalence(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('equivalence', () => equivalence(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result).toBe(false);
+		});
+
+		it('equivalence(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('equivalence', () => equivalence(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result).toBe(false);
 		});
 	});

--- a/test/scale/comparisons/pairwise-disjoint.function.scale.test.ts
+++ b/test/scale/comparisons/pairwise-disjoint.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('pairwise disjoint @ scale', () => {
-	describe('pairwise disjoint ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('pairwise disjoint ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('pairwiseDisjoint(of1):'.padEnd(padding), () => {
 			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1));
@@ -28,6 +28,16 @@ describe('pairwise disjoint @ scale', () => {
 			expect(result).toBe(false);
 		});
 
+		it('pairwiseDisjoint(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('pairwise disjoint ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('pairwiseDisjoint'));
+
 		it('pairwiseDisjoint(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(false);
@@ -41,6 +51,11 @@ describe('pairwise disjoint @ scale', () => {
 		it('pairwiseDisjoint(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf3, multiplesOf2, multiplesOf1));
 			expect(result).toBe(false);
+		});
+
+		it('pairwiseDisjoint(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('pairwiseDisjoint', () => pairwiseDisjoint(multiplesOf3, multiplesOf3B, multiplesOf3C));
+			expect(result).toBe(true);
 		});
 	});
 

--- a/test/scale/comparisons/proper-subset.function.scale.test.ts
+++ b/test/scale/comparisons/proper-subset.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('proper subset @ scale', () => {
-	describe('proper subset ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('proper subset ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('properSubset(of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSubset', () => properSubset(multiplesOf1));
@@ -28,6 +28,16 @@ describe('proper subset @ scale', () => {
 			expect(result).toBe(true);
 		});
 
+		it('properSubset(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('properSubset', () => properSubset(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('proper subset ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSubset'));
+
 		it('properSubset(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSubset', () => properSubset(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(false);
@@ -40,6 +50,11 @@ describe('proper subset @ scale', () => {
 
 		it('properSubset(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSubset', () => properSubset(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result).toBe(false);
+		});
+
+		it('properSubset(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('properSubset', () => properSubset(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result).toBe(false);
 		});
 	});

--- a/test/scale/comparisons/proper-superset.function.scale.test.ts
+++ b/test/scale/comparisons/proper-superset.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('proper superset @ scale', () => {
-	describe('proper superset ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('proper superset ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('properSuperset(of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSuperset', () => properSuperset(multiplesOf1));
@@ -28,6 +28,16 @@ describe('proper superset @ scale', () => {
 			expect(result).toBe(false);
 		});
 
+		it('properSuperset(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('properSuperset', () => properSuperset(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('proper superset ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('properSuperset'));
+
 		it('properSuperset(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSuperset', () => properSuperset(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(false);
@@ -40,6 +50,11 @@ describe('proper superset @ scale', () => {
 
 		it('properSuperset(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('properSuperset', () => properSuperset(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result).toBe(false);
+		});
+
+		it('properSuperset(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('properSuperset', () => properSuperset(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result).toBe(false);
 		});
 	});

--- a/test/scale/comparisons/subset.function.scale.test.ts
+++ b/test/scale/comparisons/subset.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('subset @ scale', () => {
-	describe('subset ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('subset ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('subset(of1):'.padEnd(padding), () => {
 			const result = Timer.time('subset', () => subset(multiplesOf1));
@@ -28,6 +28,16 @@ describe('subset @ scale', () => {
 			expect(result).toBe(true);
 		});
 
+		it('subset(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('subset', () => subset(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('subset ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('subset'));
+
 		it('subset(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('subset', () => subset(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(true);
@@ -40,6 +50,11 @@ describe('subset @ scale', () => {
 
 		it('subset(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('subset', () => subset(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result).toBe(false);
+		});
+
+		it('subset(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('subset', () => subset(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result).toBe(false);
 		});
 	});

--- a/test/scale/comparisons/superset.function.scale.test.ts
+++ b/test/scale/comparisons/superset.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('superset @ scale', () => {
-	describe('superset ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('superset ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('superset(of1):'.padEnd(padding), () => {
 			const result = Timer.time('superset', () => superset(multiplesOf1));
@@ -28,6 +28,16 @@ describe('superset @ scale', () => {
 			expect(result).toBe(false);
 		});
 
+		it('superset(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('superset', () => superset(multiplesOf2, multiplesOf2B));
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('superset ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('superset'));
+
 		it('superset(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('superset', () => superset(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result).toBe(true);
@@ -40,6 +50,11 @@ describe('superset @ scale', () => {
 
 		it('superset(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('superset', () => superset(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result).toBe(false);
+		});
+
+		it('superset(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('superset', () => superset(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result).toBe(false);
 		});
 	});

--- a/test/scale/operations/difference.function.scale.test.ts
+++ b/test/scale/operations/difference.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('difference @ scale', () => {
-	describe('difference ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('difference ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('difference(of1):'.padEnd(padding), () => {
 			const result = Timer.time('difference', () => difference(multiplesOf1));
@@ -28,6 +28,16 @@ describe('difference @ scale', () => {
 			expect(result.size).toBe(0);
 		});
 
+		it('difference(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('difference', () => difference(multiplesOf2, multiplesOf2B));
+			expect(result.size).toBe(7_500_000);
+		});
+	});
+
+	describe('difference ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('difference'));
+
 		it('difference(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('difference', () => difference(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result.size).toBe(0);
@@ -41,6 +51,11 @@ describe('difference @ scale', () => {
 		it('difference(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('difference', () => difference(multiplesOf3, multiplesOf2, multiplesOf1));
 			expect(result.size).toBe(0);
+		});
+
+		it('difference(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('difference', () => difference(multiplesOf3, multiplesOf3B, multiplesOf3C));
+			expect(result.size).toBe(5_000_000);
 		});
 	});
 

--- a/test/scale/operations/intersection.function.scale.test.ts
+++ b/test/scale/operations/intersection.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('intersection @ scale', () => {
-	describe('intersection ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('intersection ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('intersection(of1):'.padEnd(padding), () => {
 			const result = Timer.time('intersection', () => intersection(multiplesOf1));
@@ -28,6 +28,16 @@ describe('intersection @ scale', () => {
 			expect(result.size).toBe(7_500_000);
 		});
 
+		it('intersection(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('intersection', () => intersection(multiplesOf2, multiplesOf2B));
+			expect(result.size).toBe(0);
+		});
+	});
+
+	describe('intersection ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('intersection'));
+
 		it('intersection(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('intersection', () => intersection(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result.size).toBe(15_000_000);
@@ -41,6 +51,11 @@ describe('intersection @ scale', () => {
 		it('intersection(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('intersection', () => intersection(multiplesOf3, multiplesOf2, multiplesOf1));
 			expect(result.size).toBe(2_500_000);
+		});
+
+		it('intersection(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('intersection', () => intersection(multiplesOf3, multiplesOf3B, multiplesOf3C));
+			expect(result.size).toBe(0);
 		});
 	});
 

--- a/test/scale/operations/union.function.scale.test.ts
+++ b/test/scale/operations/union.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('union @ scale', () => {
-	describe('union ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('union ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('union(of1):'.padEnd(padding), () => {
 			const result = Timer.time('union', () => union(multiplesOf1));
@@ -28,6 +28,16 @@ describe('union @ scale', () => {
 			expect(result.size).toBe(15_000_000);
 		});
 
+		it('union(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('union', () => union(multiplesOf2, multiplesOf2B));
+			expect(result.size).toBe(15_000_000);
+		});
+	});
+
+	describe('union ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('union'));
+
 		it('union(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('union', () => union(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result.size).toBe(15_000_000);
@@ -40,6 +50,11 @@ describe('union @ scale', () => {
 
 		it('union(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('union', () => union(multiplesOf3, multiplesOf2, multiplesOf1));
+			expect(result.size).toBe(15_000_000);
+		});
+
+		it('union(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('union', () => union(multiplesOf3, multiplesOf3B, multiplesOf3C));
 			expect(result.size).toBe(15_000_000);
 		});
 	});

--- a/test/scale/operations/xor.function.scale.test.ts
+++ b/test/scale/operations/xor.function.scale.test.ts
@@ -5,8 +5,8 @@ import { padding, times } from '../../util/scale/scale-test.constants';
 import { Timer } from '../../util/scale/timer.model';
 
 describe('xor @ scale', () => {
-	describe('xor ⋅ large sets', () => {
-		const { multiplesOf1, multiplesOf2, multiplesOf3 } = ScaleTestSets;
+	describe('xor ⋅ 2 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf2B } = ScaleTestSets;
 
 		it('xor(of1):'.padEnd(padding), () => {
 			const result = Timer.time('xor', () => xor(multiplesOf1));
@@ -28,6 +28,16 @@ describe('xor @ scale', () => {
 			expect(result.size).toBe(7_500_000);
 		});
 
+		it('xor(of2, of2B):'.padEnd(padding), () => {
+			const result = Timer.time('xor', () => xor(multiplesOf2, multiplesOf2B));
+			expect(result.size).toBe(15_000_000);
+		});
+	});
+
+	describe('xor ⋅ 3 large sets', () => {
+		const { multiplesOf1, multiplesOf2, multiplesOf3, multiplesOf3B, multiplesOf3C } = ScaleTestSets;
+		beforeAll(() => Timer.nextLine('xor'));
+
 		it('xor(of1, of1, of1):'.padEnd(padding), () => {
 			const result = Timer.time('xor', () => xor(multiplesOf1, multiplesOf1, multiplesOf1));
 			expect(result.size).toBe(0);
@@ -41,6 +51,11 @@ describe('xor @ scale', () => {
 		it('xor(of3, of2, of1):'.padEnd(padding), () => {
 			const result = Timer.time('xor', () => xor(multiplesOf3, multiplesOf2, multiplesOf1));
 			expect(result.size).toBe(5_000_000);
+		});
+
+		it('xor(of3, of3B, of3C):'.padEnd(padding), () => {
+			const result = Timer.time('xor', () => xor(multiplesOf3, multiplesOf3B, multiplesOf3C));
+			expect(result.size).toBe(15_000_000);
 		});
 	});
 

--- a/test/util/scale/scale-test-sets.model.ts
+++ b/test/util/scale/scale-test-sets.model.ts
@@ -32,6 +32,13 @@ export abstract class ScaleTestSets {
 	/* multiples of 3, contains (3 - 15M) */
 	public static readonly multiplesOf3 = ScaleTestSets.multiplesOf(3, 5_000_000);
 
+	/* multiples of 2, part B, contains (15M+2 - 30M) */
+	public static readonly multiplesOf2B = ScaleTestSets.multiplesOf(2, 7_500_000, 15_000_000);
+	/* multiples of 3, part B, contains (15M+3 - 30M) */
+	public static readonly multiplesOf3B = ScaleTestSets.multiplesOf(3, 5_000_000, 15_000_000);
+	/* multiples of 3, part C, contains (30M+3 - 45M) */
+	public static readonly multiplesOf3C = ScaleTestSets.multiplesOf(3, 5_000_000, 30_000_000);
+
 	/* 100 equivalent sets of 100k elements */
 	public static readonly someEquivalent = ScaleTestSets.manyOf(100, 100_000);
 	/* 10k equivalent sets of 1k elements */
@@ -65,6 +72,7 @@ export abstract class ScaleTestSets {
 	]);
 
 	private static multiplesOf(factor: number, size: number, offset = 0): ReadonlySet<number> {
+		ScaleTestSets.incrementMultiplesCopied();
 		return Timer.time('copying sets', () =>
 			new Set<number>(Array.from(
 				{ length: size },
@@ -73,7 +81,7 @@ export abstract class ScaleTestSets {
 	}
 
 	private static manyOf(quantity: number, size: number, offset = false): ReadonlyArray<ReadonlySet<number>> {
-		ScaleTestSets.incrementCopiedCounts();
+		ScaleTestSets.incrementManyCopied();
 		return Timer.time('copying sets', () =>
 			Array.from(
 				{ length: quantity },
@@ -84,8 +92,14 @@ export abstract class ScaleTestSets {
 			));
 	}
 
-	private static incrementCopiedCounts(): void {
-		if (ScaleTestSets.copiedMultiples++ === 0) {
+	private static incrementMultiplesCopied(): void {
+		if (ScaleTestSets.copiedMultiples++ === 3) {
+			Timer.nextLine('copying sets');
+		}
+	}
+
+	private static incrementManyCopied(): void {
+		if (ScaleTestSets.copiedMultiples++ === 6) {
 			Timer.nextLine('copying sets');
 		}
 

--- a/test/util/scale/timer.model.ts
+++ b/test/util/scale/timer.model.ts
@@ -83,9 +83,9 @@ export abstract class Timer {
 			return AnsiFormat.fgMagenta(formattedTiming);
 		} else if (totalTiming < 5_000) {
 			return AnsiFormat.fgBlue(formattedTiming);
-		} else if (totalTiming < 20_000) {
+		} else if (totalTiming < 30_000) {
 			return AnsiFormat.fgGreen(formattedTiming);
-		} else if (totalTiming < 60_000) {
+		} else if (totalTiming < 75_000) {
 			return AnsiFormat.fgYellow(formattedTiming);
 		} else {
 			return AnsiFormat.fgRed(formattedTiming);


### PR DESCRIPTION
### added large disjoint scale tests:
Added 2 scale tests to each of the `comparisons`, and `operations` scale test suites:
1. `two disjoint 7.5M element sets`: tests `function(multiplesOf2, multiplesOf2B)`.
2. `two disjoint 5M element sets`: tests `function(multiplesOf3, multiplesOf3B, multiplesOf3C)`.

Also, split the `large sets` scale tests into 2 describes: `2 large sets` & `3 large sets`.