### PR TITLE
improved "of two sets" verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ none of the input sets are modified in the process or result of calculation.
 ## Set Operations:
 
 ### difference: `A ∖ B`
-The difference of two sets contains all the elements of the first set
-that are not contained in the second (or thereafter).
+The difference of sets contains all the elements
+of the first set, not contained in other sets.
 
 ![difference visual][]
 ```typescript
@@ -31,7 +31,8 @@ const differenceABC = difference(setA, setB, setC);
 ```
 
 ### intersection: `A ∩ B`
-The intersection of two sets contains all the elements each contained in both of the sets.
+The intersection of sets contains all the elements
+each contained in every set.
 
 ![intersection visual][]
 ```typescript
@@ -42,7 +43,8 @@ const intersectionABC = intersection(setA, setB, setC);
 ```
 
 ### union: `A ∪ B`
-The union of two sets contains all the elements contained in either set (or both sets).
+The union of sets contains all the elements
+each contained in any set.
 
 ![union visual][]
 ```typescript
@@ -53,7 +55,8 @@ const unionABC = union(setA, setB, setC);
 ```
 
 ### symmetric difference _(xor)_: `A ∆ B`
-The symmetric difference of two sets contains only the unique elements of each set.
+The symmetric difference of sets contains
+only the unique elements of each set.
 
 ![xor visual][]
 ```typescript
@@ -90,8 +93,8 @@ const isDisjointABC = disjoint(setA, setB, setC);
 ```
 
 ### pairwise disjoint: `A ∩ B ∩ C = ∅`
-A Family of Sets are pairwise disjoint if
-none of the Sets share any elements in common.
+A family of sets are pairwise disjoint if
+none of the sets share any elements in common.
 
 ![pairwise disjoint visual][]
 ```typescript

--- a/src/comparisons/pairwise-disjoint.function.ts
+++ b/src/comparisons/pairwise-disjoint.function.ts
@@ -2,8 +2,8 @@ export function pairwiseDisjoint<T>(...sets: Set<T>[]): boolean;
 export function pairwiseDisjoint<T>(...sets: ReadonlySet<T>[]): boolean;
 
 /**
- * A Family of Sets are pairwise disjoint
- * if none of the Sets share any elements in common.
+ * A family of sets are pairwise disjoint
+ * if none of the sets share any elements in common.
  *
  * Set pairwise disjoint does not have a common notation.
  * However, the disjoint union of sets is notated as A ⊔ B.

--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -2,8 +2,8 @@ export function difference<T>(...sets: Set<T>[]): Set<T>;
 export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 
 /**
- * The difference of two sets contains all the elements of the first set
- * that are not contained in the second (or thereafter).
+ * The difference of sets contains all the elements
+ * of the first set, not contained in other sets.
  *
  * Set difference is notated A ∖ B,
  * or more commonly as A - B.

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -2,7 +2,8 @@ export function intersection<T>(...sets: Set<T>[]): Set<T>;
 export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 
 /**
- * The intersection of two sets contains all the elements each contained in both of the sets.
+ * The intersection of sets contains all the elements
+ * each contained in every set.
  *
  * Set intersection is notated A ∩ B.
  *

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -2,7 +2,8 @@ export function union<T>(...sets: Set<T>[]): Set<T>;
 export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 
 /**
- * The union of two sets contains all the elements contained in either set (or both sets).
+ * The union of sets contains all the elements
+ * each contained in any set.
  *
  * Set union is notated A ∪ B.
  *

--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -2,9 +2,11 @@ export function xor<T>(...sets: Set<T>[]): Set<T>;
 export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
 
 /**
- * The symmetric difference of two sets contains only the unique elements of each set.
+ * The symmetric difference of sets contains
+ * only the unique elements of each set.
  *
- * Note: the symmetric difference of 2 sets is trivially inferred from an element-wise xor.
+ * Note: the symmetric difference of 2 sets
+ * is trivially inferred from an element-wise xor.
  *
  * Set symmetric difference is notated A ⊖ B or A ∆ B.
  *


### PR DESCRIPTION
Rewrote some documentation that specified `of two sets (or thereafter)` to be generic.