### PR TITLE
fix Jest V8 code coverage reporting

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,7 @@ const config: Config = {
 	// ],
 
 	// Indicates which provider should be used to instrument code for coverage
-	coverageProvider: 'v8',
+	coverageProvider: 'babel',
 
 	// A list of reporter names that Jest uses when writing coverage reports
 	// coverageReporters: [


### PR DESCRIPTION
### Description:
There is a bug between Jest and newer versions of V8, where code coverage of a single file is overwritten between separate tests, instead of being merged. So, a single file which is referenced in multiple tests will only report code coverage from the most recent test that was run.

In the case of this repository, the function _(file)_ being under-reported was `equivalence`. Which is used to prove the efficacy of some other unit tests. So it was being reported as missing branch coverage.

### Resources:
- https://github.com/jestjs/jest/issues/14766
- https://github.com/nodejs/node/issues/51251