### PR TITLE
bigint test suite

### DIFF
--- a/test/util/test-sets/big-int-test-sets.model.ts
+++ b/test/util/test-sets/big-int-test-sets.model.ts
@@ -1,0 +1,18 @@
+import { TestSets } from './test-sets.model';
+
+export class BigIntTestSets extends TestSets<bigint> {
+	public constructor() {
+		super(
+			BigInt(0),
+			BigInt(1),
+			BigInt(2),
+			BigInt(3),
+			BigInt(4),
+			BigInt(5),
+			BigInt(6),
+			BigInt(7),
+			BigInt(8),
+			BigInt(9),
+		);
+	}
+}

--- a/test/util/test-suite.function.ts
+++ b/test/util/test-suite.function.ts
@@ -1,5 +1,6 @@
 import { describe } from '@jest/globals';
 import { ArrayTestSets } from './test-sets/array-test-sets.model';
+import { BigIntTestSets } from './test-sets/big-int-test-sets.model';
 import { DateTestSets } from './test-sets/date-test-sets.model';
 import { EnumTestSets } from './test-sets/enum-test-sets.model';
 import { ErrorTestSets } from './test-sets/error-test-sets.model';
@@ -15,6 +16,7 @@ import { TestSets } from './test-sets/test-sets.model';
 
 export function testSuite(name: string, tests: (testSets: TestSets<unknown>) => void): void {
 	describe(`${ name } ⋅ array`, () => tests(new ArrayTestSets()));
+	describe(`${ name } ⋅ bigint`, () => tests(new BigIntTestSets()));
 	describe(`${ name } ⋅ date`, () => tests(new DateTestSets()));
 	describe(`${ name } ⋅ enum`, () => tests(new EnumTestSets()));
 	describe(`${ name } ⋅ error`, () => tests(new ErrorTestSets()));


### PR DESCRIPTION
Turns out that I missed one of the JS primitives, when originally writing these unit test suites. And that was `boolean`.

If there was a way to short circuit the test suite, and only use as many sets as there are unique values, maybe `boolean` tests would be viable. But these tests currently expect at least 10 unique values for the given type. I think that `bigint` supports at least 10 unique values.