### PR TITLE
simplified set typing

### DIFF
--- a/src/comparisons/disjoint.function.ts
+++ b/src/comparisons/disjoint.function.ts
@@ -12,7 +12,7 @@ export function disjoint<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A disjoint B ⇔ A ∩ B = ∅
  */
-export function disjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function disjoint<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/equivalence.function.ts
+++ b/src/comparisons/equivalence.function.ts
@@ -11,7 +11,7 @@ export function equivalence<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A ∼ B ⇔ (A ⊆ B) ∧ (B ⊆ A)
  */
-export function equivalence<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function equivalence<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/pairwise-disjoint.function.ts
+++ b/src/comparisons/pairwise-disjoint.function.ts
@@ -10,7 +10,7 @@ export function pairwiseDisjoint<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description pairwise disjoint F ⇔ (∀A,B ∈ F) ⇒ (A ∩ B = ∅)
  */
-export function pairwiseDisjoint<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function pairwiseDisjoint<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/proper-subset.function.ts
+++ b/src/comparisons/proper-subset.function.ts
@@ -11,7 +11,7 @@ export function properSubset<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A ⊂ B ⇔ (|A| < |B|) ∧ (∀x : (x ∈ A ⇒ x ∈ B))
  */
-export function properSubset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function properSubset<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/proper-superset.function.ts
+++ b/src/comparisons/proper-superset.function.ts
@@ -11,7 +11,7 @@ export function properSuperset<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A ⊃ B ⇔ (|A| > |B|) ∧ (∀x : (x ∈ B ⇒ x ∈ A))
  */
-export function properSuperset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function properSuperset<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/subset.function.ts
+++ b/src/comparisons/subset.function.ts
@@ -10,7 +10,7 @@ export function subset<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A ⊆ B ⇔ ∀x : (x ∈ A ⇒ x ∈ B)
  */
-export function subset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function subset<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/comparisons/superset.function.ts
+++ b/src/comparisons/superset.function.ts
@@ -10,7 +10,7 @@ export function superset<T>(...sets: ReadonlySet<T>[]): boolean;
  *
  * @description A ⊇ B ⇔ ∀x : (x ∈ B ⇒ x ∈ A)
  */
-export function superset<T, S extends ReadonlySet<T>>(...sets: S[]): boolean {
+export function superset<T>(...sets: ReadonlySet<T>[]): boolean {
 	if (sets.length < 2) {
 		return true;
 	}

--- a/src/operations/difference.function.ts
+++ b/src/operations/difference.function.ts
@@ -10,9 +10,9 @@ export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  *
  * @description A ∖ B ≔ { x : (x ∈ A) ∧ (x ∉ B) }
  */
-export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
+export function difference<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T> {
 	if (sets.length < 2) {
-		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+		return new Set<T>(sets.shift());
 	}
 
 	const resultSet = new Set<T>();
@@ -31,5 +31,5 @@ export function difference<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 		}
 	}
 
-	return resultSet as ReadonlySet<T> as S;
+	return resultSet;
 }

--- a/src/operations/intersection.function.ts
+++ b/src/operations/intersection.function.ts
@@ -9,9 +9,9 @@ export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  *
  * @description A ∩ B ≔ { x : (x ∈ A) ∧ (x ∈ B) }
  */
-export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
+export function intersection<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T> {
 	if (sets.length < 2) {
-		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+		return new Set<T>(sets.shift());
 	}
 
 	const resultSet = new Set<T>();
@@ -32,5 +32,5 @@ export function intersection<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 		}
 	}
 
-	return resultSet as ReadonlySet<T> as S;
+	return resultSet;
 }

--- a/src/operations/union.function.ts
+++ b/src/operations/union.function.ts
@@ -9,7 +9,7 @@ export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  *
  * @description A ∪ B ≔ { x : (x ∈ A) ∨ (x ∈ B) }
  */
-export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
+export function union<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T> {
 	const resultSet = new Set<T>(sets.shift());
 
 	for (const set of sets) {
@@ -18,5 +18,5 @@ export function union<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 		}
 	}
 
-	return resultSet as ReadonlySet<T> as S;
+	return resultSet;
 }

--- a/src/operations/xor.function.ts
+++ b/src/operations/xor.function.ts
@@ -12,9 +12,9 @@ export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T>;
  *
  * @description A ∆ B ≔ { x : (x ∈ A) ⊕ (x ∈ B) }
  */
-export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
+export function xor<T>(...sets: ReadonlySet<T>[]): ReadonlySet<T> {
 	if (sets.length < 2) {
-		return new Set<T>(sets.shift()) as ReadonlySet<T> as S;
+		return new Set<T>(sets.shift());
 	}
 
 	const resultSet = new Set<T>();
@@ -24,7 +24,7 @@ export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 
 	primaryLoop(primarySet, secondarySet);
 	primaryLoop(secondarySet, primarySet);
-	function primaryLoop(primary: S, secondary: S): void {
+	function primaryLoop(primary: ReadonlySet<T>, secondary: ReadonlySet<T>): void {
 		if (sets.length !== 0) {
 			for (const element of primary) {
 				if (!secondary.has(element)) {
@@ -43,7 +43,7 @@ export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 	}
 
 	sets.forEach(tertiaryLoop);
-	function tertiaryLoop(set: S, index: number): void {
+	function tertiaryLoop(set: ReadonlySet<T>, index: number): void {
 		if (index < sets.length - 1) {
 			for (const element of set) {
 				if (resultSet.has(element)) {
@@ -64,5 +64,5 @@ export function xor<T, S extends ReadonlySet<T>>(...sets: S[]): S {
 		}
 	}
 
-	return resultSet as ReadonlySet<T> as S;
+	return resultSet;
 }

--- a/src/ordering/sort.function.ts
+++ b/src/ordering/sort.function.ts
@@ -12,6 +12,6 @@ export function sort<T>(set: ReadonlySet<T>, compareFunction?: (a: T, b: T) => n
  * or specifically as A ↑ or A ↓ depending on whether
  * the sort order is ascending or descending respectively.
  */
-export function sort<T, S extends ReadonlySet<T>>(set: S, compareFunction?: (a: T, b: T) => number): S {
-	return new Set<T>(Array.from(set).sort(compareFunction)) as ReadonlySet<T> as S;
+export function sort<T>(set: ReadonlySet<T>, compareFunction?: (a: T, b: T) => number): ReadonlySet<T> {
+	return new Set<T>(Array.from(set).sort(compareFunction));
 }


### PR DESCRIPTION
The input sets are publicly declared as either `Set<T>` or `ReadonlySet<T>`. And in TypeScript, `Set` extends `ReadonlySet`. Because it is functionally the same type but with extra properties for mutability.

When this library was initially written, each function exposed a generic `S` that extended `ReadonlySet`. This guaranteed that the return type would be the same as the input set types. And, when declared types were added to this library in `v1.1.0`, that typing paradigm `S` remained. But for internal use only, as only explicit cases for `Set -> Set` and `ReadonlySet -> ReadonlySet` are exposed in the distribution.

Because there are declared types for each function, that generic is no longer internally necessary. `Set` extends `ReadonlySet`. So each function can be internally typed with `ReadonlySet`. And the `resultSets` no longer need to be cast to `S` on return.