### PR TITLE
stricter eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,10 @@
 				"import"
 			],
 			"rules": {
+				"array-bracket-spacing": [
+					"error",
+					"always"
+				],
 				"arrow-body-style": [
 					"error",
 					"as-needed"
@@ -50,6 +54,10 @@
 					"tab"
 				],
 				"max-len": "off",
+				"object-curly-spacing": [
+					"error",
+					"always"
+				],
 				"quotes": [
 					"error",
 					"single"
@@ -266,6 +274,10 @@
 				"@typescript-eslint/no-explicit-any": "error",
 				"@typescript-eslint/no-non-null-assertion": "off",
 				"@typescript-eslint/no-shadow": "error",
+				"array-bracket-spacing": [
+					"error",
+					"always"
+				],
 				"arrow-body-style": [
 					"error",
 					"as-needed"
@@ -295,6 +307,10 @@
 				],
 				"max-len": "off",
 				"no-shadow": "off",
+				"object-curly-spacing": [
+					"error",
+					"always"
+				],
 				"quotes": [
 					"error",
 					"single"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,7 @@
 					"tab"
 				],
 				"max-len": "off",
-				"no-shadow": "off",
+				"no-shadow": "error",
 				"no-var": "error",
 				"no-void": "error",
 				"no-undefined": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,10 +54,16 @@
 					"tab"
 				],
 				"max-len": "off",
+				"no-shadow": "off",
+				"no-var": "error",
+				"no-void": "error",
+				"no-undefined": "error",
 				"object-curly-spacing": [
 					"error",
 					"always"
 				],
+				"prefer-const": "error",
+				"prefer-template": "error",
 				"quotes": [
 					"error",
 					"single"
@@ -307,10 +313,15 @@
 				],
 				"max-len": "off",
 				"no-shadow": "off",
+				"no-var": "error",
+				"no-void": "error",
+				"no-undefined": "error",
 				"object-curly-spacing": [
 					"error",
 					"always"
 				],
+				"prefer-const": "error",
+				"prefer-template": "error",
 				"quotes": [
 					"error",
 					"single"

--- a/test/util/scale/timer.model.ts
+++ b/test/util/scale/timer.model.ts
@@ -23,7 +23,7 @@ export abstract class Timer {
 
 	private static add(methodName: string, timing: number): void {
 		if (!Timer.timings.has(methodName)) {
-			Timer.timings.set(methodName, [[]]);
+			Timer.timings.set(methodName, [ [] ]);
 		}
 
 		Timer.timings.get(methodName)?.slice(-1)[0]?.push(timing);
@@ -87,8 +87,10 @@ export abstract class Timer {
 			return AnsiFormat.fgGreen(formattedTiming);
 		} else if (totalTiming < 75_000) {
 			return AnsiFormat.fgYellow(formattedTiming);
-		} else {
+		} else if (totalTiming < 150_000) {
 			return AnsiFormat.fgRed(formattedTiming);
+		} else {
+			return AnsiFormat.fgWhite(formattedTiming);
 		}
 	}
 

--- a/test/util/scale/timer.model.ts
+++ b/test/util/scale/timer.model.ts
@@ -113,11 +113,6 @@ export abstract class Timer {
 	}
 
 	private static formatTiming(timing: number): string {
-		const options: Intl.NumberFormatOptions = {
-			minimumFractionDigits: 3,
-			maximumFractionDigits: 3,
-		};
-
-		return timing.toLocaleString(undefined, options) + 'ms';
+		return `${ timing.toFixed(3) }ms`;
 	}
 }

--- a/test/util/test-sets/map-test-sets.model.ts
+++ b/test/util/test-sets/map-test-sets.model.ts
@@ -8,16 +8,16 @@ export class MapTestSets extends TestSets<TestMap> {
 
 	public constructor() {
 		super(
-			new Map([[ 'id', 0 ]]),
-			new Map([[ 'id', 1 ]]),
-			new Map([[ 'id', 2 ]]),
-			new Map([[ 'id', 3 ]]),
-			new Map([[ 'id', 4 ]]),
-			new Map([[ 'id', 5 ]]),
-			new Map([[ 'id', 6 ]]),
-			new Map([[ 'id', 7 ]]),
-			new Map([[ 'id', 8 ]]),
-			new Map([[ 'id', 9 ]]),
+			new Map([ [ 'id', 0 ] ]),
+			new Map([ [ 'id', 1 ] ]),
+			new Map([ [ 'id', 2 ] ]),
+			new Map([ [ 'id', 3 ] ]),
+			new Map([ [ 'id', 4 ] ]),
+			new Map([ [ 'id', 5 ] ]),
+			new Map([ [ 'id', 6 ] ]),
+			new Map([ [ 'id', 7 ] ]),
+			new Map([ [ 'id', 8 ] ]),
+			new Map([ [ 'id', 9 ] ]),
 		);
 	}
 


### PR DESCRIPTION
Stricter linting rules with respect to the following:
- No shadowed variable names.
- No use of `var` - and preferred `const` where appropriate.
- No direct use of `undefined` or `void`.
- Preferred use of string templates over string concatenation.
- Stylistic preference of spacing in objects and arrays.